### PR TITLE
Add s3 follow redirects option.

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -6,6 +6,7 @@
           s3_scheme="https://"::string(),
           s3_host="s3.amazonaws.com"::string(),
           s3_port=80::non_neg_integer(),
+          s3_follow_redirect=false::boolean(),
           sdb_host="sdb.amazonaws.com"::string(),
           elb_host="elasticloadbalancing.amazonaws.com"::string(),
           rds_host="rds.us-east-1.amazonaws.com"::string(),

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -319,8 +319,9 @@ request_to_return(#aws_request{response_type = error,
                                error_type = aws,
                                response_status = Status,
                                response_status_line = StatusLine,
-                               response_body = Body}) ->
-    {error, {http_error, Status, StatusLine, Body}}.
+                               response_body = Body,
+                               response_headers = Headers}) ->
+    {error, {http_error, Status, StatusLine, Body, Headers}}.
 
 %% http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
 -spec sign_v4_headers(aws_config(), headers(), binary(), string(), string()) -> headers().

--- a/test/erlcloud_s3_tests.erl
+++ b/test/erlcloud_s3_tests.erl
@@ -60,7 +60,7 @@ error_handling_no_retry() ->
     Response = {ok, {{500, "Internal Server Error"}, [], <<"TestBody">>}},
     meck:expect(erlcloud_httpc, request, httpc_expect(Response)),
     Result = erlcloud_s3:get_bucket_policy("BucketName", config()),
-    ?_assertEqual({error,{http_error,500,"Internal Server Error",<<"TestBody">>}}, Result).
+    ?_assertEqual({error,{http_error,500,"Internal Server Error",<<"TestBody">>,[]}}, Result).
 
 error_handling_default_retry() ->
     Response1 = {ok, {{500, "Internal Server Error"}, [], <<"TestBody">>}},


### PR DESCRIPTION
### Problem

Requests to s3.amazonaws.com may be redirected if target bucket is located in non-default (non-US-Standart) region. Currently such requests fail.
### Solution

Adding an option into aws_config to enable following redirect response once.
