### PR TITLE
Enhance subnet, security group and image filters

### DIFF
--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -96,6 +96,7 @@
          delete_security_group/1, delete_security_group/2, delete_security_group/3,
          describe_security_groups/0, describe_security_groups/1, describe_security_groups/2,
          describe_security_groups_filtered/1, describe_security_groups_filtered/2,
+         describe_security_groups/4,
          revoke_security_group_ingress/2, revoke_security_group_ingress/3,
 
          %% Spot Instances
@@ -118,7 +119,7 @@
          get_password_data/1, get_password_data/2,
 
          %% VPC
-         describe_subnets/0, describe_subnets/1, describe_subnets/2,
+         describe_subnets/0, describe_subnets/1, describe_subnets/2, describe_subnets/3,
          create_subnet/2, create_subnet/3, create_subnet/4,
          delete_subnet/1, delete_subnet/2,
          describe_vpcs/0, describe_vpcs/1, describe_vpcs/2,
@@ -1749,7 +1750,27 @@ describe_security_groups(GroupNames) ->
 -spec(describe_security_groups/2 :: ([string()], aws_config()) -> [proplist()]).
 describe_security_groups(GroupNames, Config)
   when is_list(GroupNames) ->
-    case ec2_query(Config, "DescribeSecurityGroups", erlcloud_aws:param_list(GroupNames, "GroupName"), ?NEW_API_VERSION) of
+    describe_security_groups([], GroupNames, [], Config).
+
+-spec(describe_security_groups_filtered/1 :: (filter_list()) -> [proplist()]).
+describe_security_groups_filtered(Filter) ->
+    describe_security_groups_filtered(Filter, default_config()).
+
+-spec(describe_security_groups_filtered/2 :: (filter_list(), aws_config()) -> [proplist()]).
+describe_security_groups_filtered(Filter, Config)->
+    describe_security_groups([], [], Filter, Config).
+
+%
+% describe_security_groups functions above are left for interface backward compatibility.
+-spec(describe_security_groups/4 :: (list(), list(), list(), aws_config()) -> [proplist()]).
+describe_security_groups(GroupIds, GroupNames, Filters, Config)
+  when is_list(GroupIds),
+       is_list(GroupNames),
+       is_list(Filters) ->
+    Params = erlcloud_aws:param_list(GroupIds, "GroupId") ++
+        erlcloud_aws:param_list(GroupNames, "GroupName") ++
+        list_to_ec2_filter(Filters),
+    case ec2_query(Config, "DescribeSecurityGroups", Params, ?NEW_API_VERSION) of
         {ok, Doc} ->
             {ok, [extract_security_group(Node) ||
                 Node <- xmerl_xpath:string("/DescribeSecurityGroupsResponse/securityGroupInfo/item", Doc)]};
@@ -1757,22 +1778,6 @@ describe_security_groups(GroupNames, Config)
             Error
     end.
 
-%%
-%%
--spec(describe_security_groups_filtered/1 :: (filter_list()) -> [proplist()]).
-describe_security_groups_filtered(Filter) ->
-    describe_security_groups_filtered(Filter, default_config()).
-
--spec(describe_security_groups_filtered/2 :: (filter_list(), aws_config()) -> [proplist()]).
-describe_security_groups_filtered(Filter, Config)->
-    Params = list_to_ec2_filter(Filter),
-    case ec2_query(Config, "DescribeSecurityGroups", Params, ?NEW_API_VERSION) of
-        {ok, Doc} ->
-            Path = "/DescribeSecurityGroupsResponse/securityGroupInfo/item",
-            {ok, [extract_security_group(Node) || Node <- xmerl_xpath:string(Path, Doc)]};
-        {error, _} = Error ->
-            Error
-    end.
 
 extract_security_group(Node) ->
     [
@@ -2026,7 +2031,12 @@ describe_subnets(Filter) when is_list(Filter) ->
 
 -spec(describe_subnets/2 :: (none | filter_list(), aws_config()) -> proplist()).
 describe_subnets(Filter, Config) ->
-    Params = list_to_ec2_filter(Filter),
+    describe_subnets([], Filter, Config).
+
+-spec(describe_subnets/3 :: (list(), none | filter_list(), aws_config()) -> proplist()).
+describe_subnets(SubnetIds, Filter, Config) 
+        when is_list(SubnetIds) ->
+    Params = erlcloud_aws:param_list(SubnetIds, "SubnetId") ++ list_to_ec2_filter(Filter),
     case ec2_query(Config, "DescribeSubnets", Params, ?NEW_API_VERSION) of
         {ok, Doc} ->
             Subnets = xmerl_xpath:string("/DescribeSubnetsResponse/subnetSet/item", Doc),

--- a/test/erlcloud_ec2_tests.erl
+++ b/test/erlcloud_ec2_tests.erl
@@ -30,7 +30,8 @@ describe_tags_test_() ->
       fun describe_tags_output_tests/1,
       fun describe_vpn_gateways_tests/1,
       fun describe_customer_gateways_tests/1,
-      fun describe_vpn_connections_tests/1]}.
+      fun describe_vpn_connections_tests/1,
+      fun describe_images_tests/1]}.
 
 start() ->
     meck:new(erlcloud_httpc),
@@ -424,3 +425,51 @@ describe_vpn_connections_tests(_) ->
     
     %% Remaining AWS API examples return subsets of the same data
     output_tests(?_f(erlcloud_ec2:describe_vpn_connections()), Tests).
+
+
+describe_images_tests(_) ->
+    Tests = 
+        [?_ec2_test(
+            {"This example describes AMIs.", "
+<DescribeImagesResponse xmlns=\"http://ec2.amazonaws.com/doc/2015-04-15/\">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <imagesSet>
+      <item>
+         <imageId>ami-1a2b3c4d</imageId>
+         <imageLocation>ec2-public-windows-images/Server2003r2-x86_64-Win-v1.07.manifest.xml</imageLocation>
+         <imageState>available</imageState>
+         <imageOwnerId>123456789012</imageOwnerId>
+         <isPublic>true</isPublic>
+         <architecture>x86_64</architecture>
+         <imageType>machine</imageType>
+         <platform>windows</platform>
+         <imageOwnerAlias>amazon</imageOwnerAlias>
+         <rootDeviceType>instance-store</rootDeviceType>
+         <blockDeviceMapping/>
+         <virtualizationType>hvm</virtualizationType>
+         <tagSet/>
+         <hypervisor>xen</hypervisor>
+      </item>
+   </imagesSet>
+</DescribeImagesResponse>",
+             {ok, [[ {image_id, "ami-1a2b3c4d"},
+                     {image_location, "ec2-public-windows-images/Server2003r2-x86_64-Win-v1.07.manifest.xml"},
+                     {image_state, "available"},
+                     {image_owner_id, "123456789012"},
+                     {is_public, true},
+                     {architecture, "x86_64"},
+                     {image_type, "machine"},
+                     {kernel_id, []},
+                     {ramdisk_id, []},
+                     {image_owner_alias, "amazon"},
+                     {name, []},
+                     {description, []},
+                     {root_device_type, "instance-store"},
+                     {root_device_name, []},
+                     {platform, "windows"},
+                     {block_device_mapping, []},
+                     {product_codes, []}
+                ]]}})],
+    
+    %% Remaining AWS API examples return subsets of the same data
+    output_tests(?_f(erlcloud_ec2:describe_images()), Tests).


### PR DESCRIPTION
Filters for images can be found [here](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html). 
Security groups [here](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html).
Subnets [here](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html).
