### PR TITLE
Fix erlcloud_iam:list_users().

### DIFF
--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -111,7 +111,7 @@ list_access_keys(UserName, #aws_config{} = Config) when is_list(UserName) ->
 
 % TODO: Make sure to handle pagination of results
 -spec(list_users/0 :: () -> proplist()).
-list_users() -> list_users([]).
+list_users() -> list_users("/").
 -spec(list_users/1 :: (string() | aws_config()) -> proplist()).
 list_users(#aws_config{} = Config) ->
     list_users("/", Config);


### PR DESCRIPTION
Fix list users failure

```
17> rp(erlcloud_iam:list_users()).
{error,{http_error,400,"Bad Request",
                   <<"<ErrorResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">\n  <Error>\n    <Type>Sender</Type>\n    <Code>ValidationError</Code>\n    <Message>The specified value for pathPrefix is invalid. It must begin with the / character and contain only alphanumeric characters and/or / characters.</Message>\n  </Error>\n  <RequestId>eb968104-5ace-11e5-8ec0-d9e8283b6b40</RequestId>\n</ErrorResponse>\n">>}}
ok
```
