### PR TITLE
change erlang:error to throw

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -67,7 +67,7 @@ aws_request(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Config) 
         {ok, Body} ->
             Body;
         {error, Reason} ->
-            erlang:error({aws_error, Reason})
+            throw({aws_error, Reason})
     end.
 aws_request(Method, Protocol, Host, Port, Path, Params, AccessKeyID, SecretAccessKey) ->
     aws_request(Method, Protocol, Host, Port, Path, Params,

--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -513,6 +513,6 @@ elb_request(Config, Action, Params) ->
     of
         {ok, Body} ->
             Body;
-        {error, Reason} ->
-            erlang:error({aws_error, Reason})
+        {error, Reason} = E->
+            E
     end.

--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -513,6 +513,6 @@ elb_request(Config, Action, Params) ->
     of
         {ok, Body} ->
             Body;
-        {error, Reason} = E->
-            E
+        {error, Reason} ->
+            {error, Reason}
     end.

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1046,8 +1046,8 @@ s3_request(Config, Method, Host, Path, Subreasource, Params, POSTData, Headers) 
     case s3_request2(Config, Method, Host, Path, Subreasource, Params, POSTData, Headers) of
         {ok, Result} ->
             Result;
-        {error, Reason} = E ->
-            E
+        {error, Reason}->
+            {error, Reason}
     end.
 
 %% s3_request2 returns {ok, Body} or {error, Reason} instead of throwing as s3_request does

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1024,7 +1024,7 @@ s3_simple_request(Config, Method, Host, Path, Subresource, Params, POSTData, Hea
                 #xmlElement{name='Error'} ->
                     ErrCode = erlcloud_xml:get_text("/Error/Code", XML),
                     ErrMsg = erlcloud_xml:get_text("/Error/Message", XML),
-                    erlang:error({s3_error, ErrCode, ErrMsg});
+                    throw({s3_error, ErrCode, ErrMsg});
                 _ ->
                     ok
             end
@@ -1037,7 +1037,7 @@ s3_xml_request(Config, Method, Host, Path, Subresource, Params, POSTData, Header
         #xmlElement{name='Error'} ->
             ErrCode = erlcloud_xml:get_text("/Error/Code", XML),
             ErrMsg = erlcloud_xml:get_text("/Error/Message", XML),
-            erlang:error({s3_error, ErrCode, ErrMsg});
+            throw({s3_error, ErrCode, ErrMsg});
         _ ->
             XML
     end.
@@ -1046,8 +1046,8 @@ s3_request(Config, Method, Host, Path, Subreasource, Params, POSTData, Headers) 
     case s3_request2(Config, Method, Host, Path, Subreasource, Params, POSTData, Headers) of
         {ok, Result} ->
             Result;
-        {error, Reason} ->
-            erlang:error({aws_error, Reason})
+        {error, Reason} = E ->
+            E
     end.
 
 %% s3_request2 returns {ok, Body} or {error, Reason} instead of throwing as s3_request does

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -390,8 +390,8 @@ sqs_xml_request(Config, QueueName, Action, Params) ->
     of
         {ok, Body} ->
             Body;
-        {error, Reason} ->
-            erlang:error({aws_error, Reason})
+        {error, Reason} = E->
+            E
     end.
 
 sqs_request(Config, QueueName, Action, Params) ->
@@ -403,8 +403,8 @@ sqs_request(Config, QueueName, Action, Params) ->
     of
         {ok, Body} ->
             Body;
-        {error, Reason} ->
-            erlang:error({aws_error, Reason})
+        {error, Reason} = E ->
+            E
     end.
 
 queue_path([$/|_] = QueueName) -> QueueName;

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -390,8 +390,8 @@ sqs_xml_request(Config, QueueName, Action, Params) ->
     of
         {ok, Body} ->
             Body;
-        {error, Reason} = E->
-            E
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 sqs_request(Config, QueueName, Action, Params) ->
@@ -403,8 +403,8 @@ sqs_request(Config, QueueName, Action, Params) ->
     of
         {ok, Body} ->
             Body;
-        {error, Reason} = E ->
-            E
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 queue_path([$/|_] = QueueName) -> QueueName;

--- a/src/erlcloud_sts.erl
+++ b/src/erlcloud_sts.erl
@@ -109,6 +109,6 @@ sts_query(AwsConfig, Action, Params, ApiVersion) ->
     of
         {ok, Body} ->
             Body;
-        {error, Reason} = E ->
-            E
+        {error, Reason} ->
+           {error, Reason}
     end.

--- a/src/erlcloud_sts.erl
+++ b/src/erlcloud_sts.erl
@@ -109,6 +109,6 @@ sts_query(AwsConfig, Action, Params, ApiVersion) ->
     of
         {ok, Body} ->
             Body;
-        {error, Reason} ->
-            erlang:error({aws_error, Reason})
+        {error, Reason} = E ->
+            E
     end.


### PR DESCRIPTION
we see that S3/SNS very often fails with {aws_error, {socket_error, timeout}} in a very nasty way crashing the process. make the errors slightly better.

PS: not all `erlang:error()`'s  are changed.
