### PR TITLE
Fix `erlcloud_kinesis:describe_stream`

### DIFF
--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -238,7 +238,7 @@ describe_stream(StreamName, Limit, ExcludeShard) when is_integer(Limit), Limit >
 
 describe_stream(StreamName, Limit, ExcludeShard, Config) when is_record(Config, aws_config), is_integer(Limit), Limit > 0, Limit =< 100 ->
    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}, {<<"ExclusiveStartShardId">>, ExcludeShard}],
-   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.DescribeStream", Json).
+   erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json).
 
 
 %%------------------------------------------------------------------------------

--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -212,33 +212,33 @@ list_streams(ExclusiveStartStreamName, Limit, Config) when is_record(Config, aws
 %%------------------------------------------------------------------------------
 
 -spec describe_stream/1 :: (string()) -> proplist().
-
 describe_stream(StreamName) ->
    describe_stream(StreamName, default_config()).
 
--spec describe_stream/2 :: (string(), 1..100 | aws_config()) -> proplist().
-
+-spec describe_stream/2 :: (string(), 1..10000 | aws_config()) -> proplist().
 describe_stream(StreamName, Config) when is_record(Config, aws_config) ->
-   Json = [{<<"StreamName">>, StreamName}],
-   erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json);
-describe_stream(StreamName, Limit) when is_integer(Limit), Limit > 0, Limit =< 100 ->
-   Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}],
-   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.DescribeStream", Json).
+    Json = [{<<"StreamName">>, StreamName}],
+    erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json);
+describe_stream(StreamName, Limit) ->
+    describe_stream(StreamName, Limit, default_config()).
 
--spec describe_stream/3 :: (string(), 1..100, string() | aws_config()) -> proplist().
+-spec describe_stream/3 :: (string(), 1..10000, string() | aws_config()) -> proplist().
+describe_stream(StreamName, Limit, Config)
+  when is_record(Config, aws_config),
+       is_integer(Limit),
+       Limit >= 1, Limit =< 10000 ->
+    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}],
+    erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json);
+describe_stream(StreamName, Limit, ExcludeShard) ->
+    describe_stream(StreamName, Limit, ExcludeShard, default_config()).
 
-describe_stream(StreamName, Limit, Config) when is_record(Config, aws_config) ->
-   Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}],
-   erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json);
-describe_stream(StreamName, Limit, ExcludeShard) when is_integer(Limit), Limit > 0, Limit =< 100 ->
-   Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}, {<<"ExclusiveStartShardId">>, ExcludeShard}],
-   erlcloud_kinesis_impl:request(default_config(), "Kinesis_20131202.DescribeStream", Json).
-
--spec describe_stream/4 :: (string(), 1..100, string(), aws_config()) -> proplist().
-
-describe_stream(StreamName, Limit, ExcludeShard, Config) when is_record(Config, aws_config), is_integer(Limit), Limit > 0, Limit =< 100 ->
-   Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}, {<<"ExclusiveStartShardId">>, ExcludeShard}],
-   erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json).
+-spec describe_stream/4 :: (string(), 1..10000, string(), aws_config()) -> proplist().
+describe_stream(StreamName, Limit, ExcludeShard, Config)
+  when is_record(Config, aws_config),
+       is_integer(Limit),
+       Limit >= 1, Limit =< 10000 ->
+    Json = [{<<"StreamName">>, StreamName}, {<<"Limit">>, Limit}, {<<"ExclusiveStartShardId">>, ExcludeShard}],
+    erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.DescribeStream", Json).
 
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
- `Config` is not propagated in `describe_stream/4`, `default_config()` was used there instead.
- `Limit` can be in range `1..10000`, not `1..100`, see [APIReference](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_DescribeStream.html#Kinesis-DescribeStream-request-Limit).
