### PR TITLE
move covertool to bottom of deps to avoid rebar failure on compiling

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,11 +15,11 @@
   warn_unused_record,
   warn_unused_vars]}.
 
-{deps, [{covertool, "", {git, "https://github.com/idubrov/covertool.git", "master"}},
-        {meck, ".*", {git, "https://github.com/eproxus/meck.git", "master"}},
+{deps, [{meck, ".*", {git, "https://github.com/eproxus/meck.git", "master"}},
         {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", "master"}},
         %% {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {tag, "1.2.0"}}},
-        {lhttpc, ".*", {git, "git://github.com/talko/lhttpc", "master"}}
+        {lhttpc, ".*", {git, "git://github.com/talko/lhttpc", "master"}},
+        {covertool, "", {git, "https://github.com/idubrov/covertool.git", "master"}}
        ]}.
 
 {plugins, [rebar_covertool]}.


### PR DESCRIPTION
I guess this isn't happening in travis for whatever reason, but our builds internally in jenkins are failing like this:

``` sh
$ make
==> rebar (get-deps)
==> covertool (get-deps)
==> meck (get-deps)
==> jsx (get-deps)
==> lhttpc (get-deps)
==> erlcloud (get-deps)
==> rebar (compile)
ERROR: compile failed while processing /Users/nal/src/alertlogic/erlang/erlcloud/deps/rebar: {'EXIT',{undef,[{rebar_utils,find_files_by_ext,["src",".abnf",true],[]},
                {rebar_base_compiler,run,8,
                                     [{file,"src/rebar_base_compiler.erl"},
                                      {line,69}]},
                {rebar_core,run_modules,4,
                            [{file,"src/rebar_core.erl"},{line,490}]},
                {rebar_core,execute,6,
                            [{file,"src/rebar_core.erl"},{line,415}]},
                {rebar_core,maybe_execute,8,
                            [{file,"src/rebar_core.erl"},{line,299}]},
                {rebar_core,process_dir1,7,
                            [{file,"src/rebar_core.erl"},{line,258}]},
                {rebar_core,process_each,5,
                            [{file,"src/rebar_core.erl"},{line,348}]},
                {rebar_core,process_dir1,7,
                            [{file,"src/rebar_core.erl"},{line,250}]}]}}
```

this seems to have something to do with how the `covertool` dep pulls down rebar, but I don't fully understand it. Moving covertool to be something other than the first dep resolves the problem, and I propose doing that.
