### PR TITLE
Add bucket path-style access method. Add sequential redirects handling.

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -7,6 +7,8 @@
           s3_host="s3.amazonaws.com"::string(),
           s3_port=80::non_neg_integer(),
           s3_follow_redirect=false::boolean(),
+          s3_follow_redirect_count=2::non_neg_integer(),
+          s3_bucket_access_method=vhost::vhost|path,
           s3_bucket_after_host=false::boolean(),
           sdb_host="sdb.amazonaws.com"::string(),
           elb_host="elasticloadbalancing.amazonaws.com"::string(),


### PR DESCRIPTION
#### Problem.

AWS return 404 if trying to access buckets with non-DNS-compliant names using virtual-hosted method.
#### Solution.

In order to access buckets with non-DNS-compliant names path-style access should be used.
Bucket access method is now to be set in aws_config (virtual-hosted by default).
Redirects handling was changed also to:
- follow (by default up to 2) sequential redirects;
- detect bucket access method from a redirected hostname.
