### PR TITLE
Add retry support into erlcloud_aws.erl

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -59,7 +59,8 @@
           hackney_pool=default::atom(), %% The name of the http request pool hackney should use.
           %% Default to not retry failures (for backwards compatability).
           %% Recommended to be set to default_retry to provide recommended retry behavior.
-          %% Currently only affects S3, but intent is to change other services to use this as well.
+          %% Currently only affects S3 and service modules which use erlcloud_aws 
+          %% for issuing HTTP request to AWS, but intent is to change other services to use this as well.
           %% If you provide a custom function be aware of this anticipated change.
           %% See erlcloud_retry for full documentation.
           retry=fun erlcloud_retry:no_retry/1::erlcloud_retry:retry_fun(),

--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -62,14 +62,17 @@
           %% Currently only affects S3, but intent is to change other services to use this as well.
           %% If you provide a custom function be aware of this anticipated change.
           %% See erlcloud_retry for full documentation.
-          retry=fun erlcloud_retry:no_retry/1::erlcloud_retry:retry_fun()
+          retry=fun erlcloud_retry:no_retry/1::erlcloud_retry:retry_fun(),
+          %% Currently matches DynamoDB retry
+          %% It's likely this is too many retries for other services
+          retry_num=10::non_neg_integer()
          }).
 -type(aws_config() :: #aws_config{}).
 
 -record(aws_request,
         {
           %% Provided by requesting service
-          service :: s3,
+          service :: atom(),
           uri :: string() | binary(),
           method :: atom(),
           request_headers :: [{string(), string()}],

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -126,14 +126,14 @@ aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service, #aws
     Region = aws_region_from_host(Host),
 
     SignedHeaders = case Method of
-                        post ->
-                            sign_v4(Method, Path, Config,
-                                    [{"host", Host}], list_to_binary(Query),
-                                    Region, Service, []);
-                        get ->
-                            sign_v4(Method, Path, Config, [{"host", Host}],
-                                    [], Region, Service, Params)
-                    end,
+        M when M =:= get orelse M =:= head orelse M =:= delete ->
+            sign_v4(M, Path, Config, [{"host", Host}],
+                    [], Region, Service, Params);
+        _ ->
+            sign_v4(Method, Path, Config,
+                    [{"host", Host}], list_to_binary(Query),
+                    Region, Service, [])
+    end,
 
     aws_request_form(Method, Protocol, Host, Port, Path, Query, SignedHeaders, Config).
 
@@ -151,24 +151,51 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
         undefined -> [UProtocol, Host, Path];
         _ -> [UProtocol, Host, $:, port_to_str(Port), Path]
     end,
-
+    
+    ResultFun = 
+        fun(#aws_request{response_type = ok} = Request) ->
+                Request;
+           (#aws_request{response_type = error,
+                         error_type = aws,
+                         response_status = Status} = Request) when
+                    Status == 400; Status >= 500 ->
+                Request#aws_request{should_retry = true};
+           (#aws_request{response_type = error} = Request) ->
+                Request#aws_request{should_retry = false}
+        end,
+    
     %% Note: httpc MUST be used with {timeout, timeout()} option
     %%       Many timeout related failures is observed at prod env
     %%       when library is used in 24/7 manner
     Response =
         case Method of
-            get ->
+            M when M =:= get orelse M =:= head orelse M =:= delete ->
                 Req = lists:flatten([URL, $?, Form]),
-                erlcloud_httpc:request(
-                  Req, get, Headers, <<>>, Config#aws_config.timeout, Config);
+                AwsRequest = #aws_request{uri = Req, 
+                                          method = M,
+                                          request_headers = Headers,
+                                          request_body = <<>>},
+                erlcloud_retry:request(Config, AwsRequest, ResultFun);
             _ ->
-                erlcloud_httpc:request(
-                  lists:flatten(URL), Method,
-                  [{<<"content-type">>, <<"application/x-www-form-urlencoded; charset=utf-8">>} | Headers],
-                  list_to_binary(Form), Config#aws_config.timeout, Config)
+                RequestHeaders = 
+                    [{"content-type", 
+                      "application/x-www-form-urlencoded; charset=utf-8"} | 
+                     Headers],
+                AwsRequest = #aws_request{uri = lists:flatten(URL), 
+                                          method = Method,
+                                          request_headers = RequestHeaders,
+                                          request_body = list_to_binary(Form)},
+                erlcloud_retry:request(Config, AwsRequest, ResultFun)
         end,
 
-    http_body(Response).
+    case request_to_return(Response) of
+        {ok, {_, Body}} ->
+            {ok, Body};
+        {error, {Error, StatusCode, StatusLine, Body, _Headers}} ->
+            {error, {Error, StatusCode, StatusLine, Body}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 param_list([], _Key) -> [];
 param_list(Values, Key) when is_tuple(Key) ->

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -160,7 +160,8 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
                          response_status = Status} = Request) when
                 %% Retry for 400, Bad Request is needed due to Amazon 
                 %% returns it in case of throttling
-                    Status == 400; Status >= 500 ->
+                %% %% Also retry conflictin operations 409,Conflict.
+                    Status == 400; Status == 409; Status >= 500 ->
                 Request#aws_request{should_retry = true};
            (#aws_request{response_type = error} = Request) ->
                 Request#aws_request{should_retry = false}

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -158,6 +158,8 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
            (#aws_request{response_type = error,
                          error_type = aws,
                          response_status = Status} = Request) when
+                %% Retry for 400, Bad Request is needed due to Amazon 
+                %% returns it in case of throttling
                     Status == 400; Status >= 500 ->
                 Request#aws_request{should_retry = true};
            (#aws_request{response_type = error} = Request) ->

--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -20,18 +20,18 @@
 %% Helpers
 -export([backoff/1, 
          no_retry/1,
-         default_retry/1, default_retry/2
+         default_retry/1
         ]).
 -export_type([should_retry/0, retry_fun/0]).
 
 -type should_retry() :: {retry | error, #aws_request{}}.
--type retry_fun() :: fun((#aws_request{}) -> should_retry()).
+-type retry_fun() :: fun((#aws_request{}, non_neg_integer()) -> should_retry()).
 
 %% Internal impl api
 -export([request/3]).
 
 %% Error returns maintained for backwards compatibility
--spec no_retry(#aws_request{}) -> should_retry().
+-spec no_retry(#aws_request{}) -> {error, #aws_request{}}.
 no_retry(Request) ->
     {error, Request}.
 
@@ -41,30 +41,22 @@ backoff(1) -> ok;
 backoff(Attempt) ->
     timer:sleep(random:uniform((1 bsl (Attempt - 1)) * 100)).
 
-%% Currently matches DynamoDB retry
-%% It's likely this is too many retries for other services
--define(NUM_ATTEMPTS, 10).
-
 -spec default_retry(#aws_request{}) -> should_retry().
-default_retry(Request) ->
-    default_retry(Request, ?NUM_ATTEMPTS).
-
--spec default_retry(#aws_request{}, integer()) -> should_retry().
-default_retry(#aws_request{attempt = Attempt} = Request, MaxAttempts) 
-  when Attempt >= MaxAttempts ->
+default_retry(#aws_request{should_retry = false} = Request) ->
     {error, Request};
-default_retry(#aws_request{should_retry = false} = Request, _) ->
-    {error, Request};
-default_retry(#aws_request{attempt = Attempt} = Request, _) ->
+default_retry(#aws_request{attempt = Attempt} = Request) ->
     backoff(Attempt),
     {retry, Request}.
 
 request(Config, #aws_request{attempt = 0} = Request, ResultFun) ->
-    request_and_retry(Config, ResultFun, {retry, Request}).
+    MaxAttempts = Config#aws_config.retry_num,
+    request_and_retry(Config, ResultFun, {retry, Request}, MaxAttempts).
 
-request_and_retry(_, _, {error, Request}) ->
+request_and_retry(_, _, {_, Request}, 0) ->
     Request;
-request_and_retry(Config, ResultFun, {retry, Request}) ->
+request_and_retry(_, _, {error, Request}, _) ->
+    Request;
+request_and_retry(Config, ResultFun, {retry, Request}, MaxAttempts) ->
     #aws_request{
        attempt = Attempt,
        uri = URI,
@@ -77,23 +69,31 @@ request_and_retry(Config, ResultFun, {retry, Request}) ->
     case erlcloud_httpc:request(URI, Method, Headers, Body, Config#aws_config.timeout, Config) of
         {ok, {{Status, StatusLine}, ResponseHeaders, ResponseBody}} ->
             Request3 = Request2#aws_request{
-                         response_type = if Status >= 200, Status < 300 -> ok; true -> error end,
-                         error_type = aws,
-                         response_status = Status,
-                         response_status_line = StatusLine,
-                         response_headers = ResponseHeaders,
-                         response_body = ResponseBody},
+                 response_type = if Status >= 200, Status < 300 -> ok; true -> error end,
+                 error_type = aws,
+                 response_status = Status,
+                 response_status_line = StatusLine,
+                 response_headers = ResponseHeaders,
+                 response_body = ResponseBody},
             Request4 = ResultFun(Request3),
             case Request4#aws_request.response_type of
                 ok ->
                     Request4;
                 error ->
-                    request_and_retry(Config, ResultFun, RetryFun(Request4))
+                    request_and_retry(
+                        Config, 
+                        ResultFun, 
+                        RetryFun(Request4),
+                        MaxAttempts - 1)
             end;
         {error, Reason} ->
             Request4 = Request2#aws_request{
                          response_type = error,
                          error_type = httpc,
                          httpc_error_reason = Reason},
-            request_and_retry(Config, ResultFun, RetryFun(Request4))
+            request_and_retry(
+                Config, 
+                ResultFun, 
+                RetryFun(Request4),
+                MaxAttempts - 1)
     end.

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1190,7 +1190,9 @@ s3_result_fun(#aws_request{response_type = ok} = Request) ->
 s3_result_fun(#aws_request{response_type = error,
                            error_type = aws,
                            response_status = Status} = Request) when
-      Status >= 500 ->
+%% Retry for 400, Bad Request is needed due to Amazon 
+%% returns it in case of throttling
+      Status =:= 400; Status >= 500 ->
     Request#aws_request{should_retry = true};
 s3_result_fun(#aws_request{response_type = error, error_type = aws} = Request) ->
     Request#aws_request{should_retry = false}.

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1191,8 +1191,9 @@ s3_result_fun(#aws_request{response_type = error,
                            error_type = aws,
                            response_status = Status} = Request) when
 %% Retry for 400, Bad Request is needed due to Amazon 
-%% returns it in case of throttling
-      Status =:= 400; Status >= 500 ->
+%% returns it in case of throttling.
+%% Also retry conflictin operations 409,Conflict.
+      Status =:= 400; Status =:= 409; Status >= 500 ->
     Request#aws_request{should_retry = true};
 s3_result_fun(#aws_request{response_type = error, error_type = aws} = Request) ->
     Request#aws_request{should_retry = false}.


### PR DESCRIPTION
Retry option in `#aws_config{}` affected S3 only, "but intent is to change other services to use this as well".
So reuse erlcloud_retry in erlcloud_aws.erl
