### PR TITLE
Add support for Lambda

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -8,7 +8,7 @@
           s3_port=80::non_neg_integer(),
           s3_follow_redirect=false::boolean(),
           s3_follow_redirect_count=2::non_neg_integer(),
-          %% When set to 'auto' access method is chosen 
+          %% When set to 'auto' access method is chosen
           %% according to a bucket name:
           %%    * non-DNS-compliant name - 'path'
           %%    * DNS-compliant or empty name - 'vhost'
@@ -37,6 +37,9 @@
           route53_scheme="https://"::string(),
           route53_host="route53.amazonaws.com"::string(),
           route53_port="80"::string(),
+          lambda_scheme="https://"::string(),
+          lambda_host="lambda.us-east-1.amazonaws.com"::string(),
+          lambda_port=443::non_neg_integer(),
           kinesis_scheme="https://"::string(),
           kinesis_host="kinesis.us-east-1.amazonaws.com"::string(),
           kinesis_port=80::non_neg_integer(),
@@ -63,7 +66,7 @@
           hackney_pool=default::atom(), %% The name of the http request pool hackney should use.
           %% Default to not retry failures (for backwards compatability).
           %% Recommended to be set to default_retry to provide recommended retry behavior.
-          %% Currently only affects S3 and service modules which use erlcloud_aws 
+          %% Currently only affects S3 and service modules which use erlcloud_aws
           %% for issuing HTTP request to AWS, but intent is to change other services to use this as well.
           %% If you provide a custom function be aware of this anticipated change.
           %% See erlcloud_retry for full documentation.

--- a/include/erlcloud_lambda.hrl
+++ b/include/erlcloud_lambda.hrl
@@ -1,0 +1,2 @@
+-record(erlcloud_lambda_code, {s3Bucket, s3Key, s3ObjectVersion, zipFile}).
+-type(erlcloud_lambda_code() :: #erlcloud_lambda_code{}).

--- a/src/erlcloud_lambda.erl
+++ b/src/erlcloud_lambda.erl
@@ -1,0 +1,704 @@
+-module(erlcloud_lambda).
+-author('eholland@alertlogic.com').
+
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
+-include("erlcloud_lambda.hrl").
+
+-define(API_VERSION, "2015-03-31").
+
+%%% Library initialization.
+-export([configure/2, configure/3, configure/4,
+         new/2, new/3, new/4]).
+-export([create_alias/4, create_alias/5,
+         create_event_source_mapping/4, create_event_source_mapping/5,
+         create_function/6, create_function/7,
+         delete_event_source_mapping/1, delete_event_source_mapping/2,
+         get_alias/2, get_alias/3,
+         get_event_source_mapping/1, get_event_source_mapping/2,
+         get_function/1, get_function/2, get_function/3,
+         get_function_configuration/1, get_function_configuration/2, get_function_configuration/3,
+         list_aliases/1, list_aliases/2, list_aliases/4, list_aliases/5,
+         list_event_source_mappings/2, list_event_source_mappings/4, list_event_source_mappings/5,
+         list_functions/0, list_functions/2, list_functions/3,
+         list_versions_by_function/1, list_versions_by_function/3, list_versions_by_function/4,
+         publish_version/1, publish_version/3, publish_version/4,
+         update_alias/2, update_alias/4, update_alias/5,
+         update_event_source_mapping/4, update_event_source_mapping/5,
+         update_function_code/3, update_function_code/4,
+         update_function_configuration/6, update_function_configuration/7]).
+
+-type(runtime()     :: 'nodejs' | 'java8' | 'python2.7').
+-type(return_val()  :: any()).
+
+
+
+%%------------------------------------------------------------------------------
+%% Library initialization.
+%%------------------------------------------------------------------------------
+
+-spec new(string(), string()) -> aws_config().
+
+new(AccessKeyID, SecretAccessKey) ->
+    #aws_config{
+       access_key_id=AccessKeyID,
+       secret_access_key=SecretAccessKey
+      }.
+
+-spec new(string(), string(), string()) -> aws_config().
+
+new(AccessKeyID, SecretAccessKey, Host) ->
+    #aws_config{
+       access_key_id=AccessKeyID,
+       secret_access_key=SecretAccessKey,
+       lambda_host=Host
+      }.
+
+-spec new(string(), string(), string(), non_neg_integer()) -> aws_config().
+
+new(AccessKeyID, SecretAccessKey, Host, Port) ->
+    #aws_config{
+       access_key_id=AccessKeyID,
+       secret_access_key=SecretAccessKey,
+       lambda_host=Host,
+       lambda_port=Port
+      }.
+
+-spec configure(string(), string()) -> ok.
+
+configure(AccessKeyID, SecretAccessKey) ->
+    put(aws_config, new(AccessKeyID, SecretAccessKey)),
+    ok.
+
+-spec configure(string(), string(), string()) -> ok.
+
+configure(AccessKeyID, SecretAccessKey, Host) ->
+    put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
+    ok.
+
+-spec configure(string(), string(), string(), non_neg_integer()) -> ok.
+
+configure(AccessKeyID, SecretAccessKey, Host, Port) ->
+    put(aws_config, new(AccessKeyID, SecretAccessKey, Host, Port)),
+    ok.
+
+default_config() ->
+    erlcloud_aws:default_config().
+
+%%------------------------------------------------------------------------------
+%% CreateAlias
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+-spec create_alias/4 :: (FunctionName    :: binary(),
+                         FunctionVersion :: binary(),
+                         AliasName       :: binary(),
+                         Options         :: proplist()) -> return_val().
+
+create_alias(FunctionName, FunctionVersion, AliasName, Options) ->
+create_alias(FunctionName, FunctionVersion,
+                 AliasName, Options, default_config()).
+
+-spec create_alias/5 :: (FunctionName    :: binary(),
+                         FunctionVersion :: binary(),
+                         AliasName       :: binary(),
+                         Options         :: proplist(),
+                         Config          :: aws_config()) -> return_val().
+create_alias(FunctionName, FunctionVersion, AliasName, Options, Config) ->
+    Path = base_path() ++ "functions/" ++  binary_to_list(FunctionName) ++ "/aliases",
+    Json = [{<<"FunctionVersion">>, FunctionVersion},
+            {<<"Name">>, AliasName}
+            | Options],
+    lambda_request(Config, post, Path, Json).
+
+%%------------------------------------------------------------------------------
+%% CreateEventSourceMapping
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+-spec create_event_source_mapping/4 :: (EventSourceArn   :: binary(),
+                                        FunctionName     :: binary(),
+                                        StartingPosition :: binary(),
+                                        Options          :: proplist())
+                                       -> return_val().
+create_event_source_mapping(EventSourceArn, FunctionName,
+                            StartingPosition, Options) ->
+    create_event_source_mapping(EventSourceArn, FunctionName,
+                                StartingPosition, Options, default_config()).
+
+-spec create_event_source_mapping/5 :: (EventSourceArn   :: binary(),
+                                        FunctionName     :: binary(),
+                                        StartingPosition :: binary(),
+                                        Options          :: proplist(),
+                                        Config           :: aws_config())
+                                       -> return_val().
+create_event_source_mapping(EventSourceArn, FunctionName,
+                            StartingPosition, Options, Config) ->
+    Path = base_path() ++ "event-source-mappings",
+    Json = [{<<"EventSourceArn">>, EventSourceArn},
+            {<<"FunctionName">>, FunctionName},
+            {<<"StartingPosition">>, StartingPosition}
+            | Options],
+    lambda_request(Config, post, Path, Json).
+
+
+%%------------------------------------------------------------------------------
+%% CreateFunction
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+-spec create_function/6 :: (Code         :: erlcloud_lambda_code(),
+                            FunctionName :: string(),
+                            Handler      :: string(),
+                            Role         :: string(),
+                            Runtime      :: runtime(),
+                            Options      :: proplist()) -> return_val().
+create_function(#erlcloud_lambda_code{} = Code,
+                FunctionName, Handler, Role, Runtime, Options) ->
+    create_function(Code, FunctionName, Handler, Role,
+                    Runtime, Options, default_config()).
+
+-spec create_function/7 :: (Code         :: erlcloud_lambda_code(),
+                            FunctionName :: string(),
+                            Handler      :: string(),
+                            Role         :: string(),
+                            Runtime      :: runtime(),
+                            Options      :: proplist(),
+                            Config       :: aws_config()) -> return_val().
+create_function(#erlcloud_lambda_code{} = Code,
+                FunctionName, Handler, Role, Runtime, Options, Config) ->
+    Json = [{<<"Code">>, from_record(Code)},
+            {<<"FunctionName">>, FunctionName},
+            {<<"Handler">>, Handler},
+            {<<"Role">>, Role},
+            {<<"Runtime">>, Runtime}
+            | Options],
+    Path = base_path() ++ "functions",
+    lambda_request(Config, post, Path, Json).
+
+%%------------------------------------------------------------------------------
+%% DeleteEventSourceMapping
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_DeleteEventSourceMapping.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec delete_event_source_mapping/1 :: (Uuid :: binary()) -> return_val().
+delete_event_source_mapping(Uuid) ->
+    delete_event_source_mapping(Uuid, default_config()).
+
+-spec delete_event_source_mapping/2 :: (Uuid   :: binary(),
+                                        Config :: aws_config()) -> return_val().
+delete_event_source_mapping(Uuid, Config) ->
+    Path = base_path() ++ "event-source-mappings/" ++ binary_to_list(Uuid),
+    lambda_request(Config, delete, Path, undefined).
+
+
+%%------------------------------------------------------------------------------
+%% GetAlias
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_GetAlias.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec get_alias(FunctionName :: binary(),
+                Name         :: binary()) -> return_val().
+get_alias(FunctionName, Name) ->
+    get_alias(FunctionName, Name, default_config()).
+
+-spec get_alias(FunctionName :: binary(),
+                Name         :: binary(),
+                Config       :: aws_config()) -> return_val().
+get_alias(FunctionName, Name, Config) ->
+    Path = base_path() ++ "functions/"
+        ++ binary_to_list(FunctionName) ++ "/aliases/" ++ binary_to_list(Name),
+    lambda_request(Config, get, Path, undefined).
+
+%%------------------------------------------------------------------------------
+%% GetEventSourceMapping
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec get_event_source_mapping(Uuid :: binary()) -> return_val().
+get_event_source_mapping(Uuid) ->
+    get_event_source_mapping(Uuid, default_config()).
+
+-spec get_event_source_mapping(Uuid   :: binary(),
+                               Config :: aws_config()) -> return_val().
+get_event_source_mapping(Uuid, Config) ->
+    Path = base_path() ++ "event-source-mappings/" ++ binary_to_list(Uuid),
+    lambda_request(Config, get, Path, undefined).
+
+%%------------------------------------------------------------------------------
+%% GetFunction
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec get_function(FunctionName :: binary()) -> return_val().
+get_function(FunctionName) ->
+    get_function(FunctionName, default_config()).
+
+-spec get_function(FunctionName :: binary(),
+                   Config       :: aws_config()) -> return_val().
+get_function(FunctionName, Config) ->
+    get_function(FunctionName, undefined, Config).
+
+-spec get_function(FunctionName :: binary(),
+                   Qualifier    :: binary(),
+                   Config       :: aws_config()) -> return_val().
+get_function(FunctionName, Qualifier, Config) ->
+    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName),
+    QParams = filter_undef([{"Qualifier", Qualifier}]),
+    lambda_request(Config, get, Path, undefined, QParams).
+
+%%------------------------------------------------------------------------------
+%% GetFunctionConfiguration
+%%------------------------------------------------------------------------------
+
+-spec get_function_configuration(FunctionName :: binary()) -> return_val().
+get_function_configuration(FunctionName) ->
+    get_function_configuration(FunctionName, default_config()).
+
+-spec get_function_configuration(FunctionName :: binary(),
+                                 Config       :: aws_config()) -> return_val().
+get_function_configuration(FunctionName, Config) ->
+    get_function_configuration(FunctionName, undefined, Config).
+
+get_function_configuration(Function, Qualifier, Config) ->
+    Path = base_path() ++ "functions/" ++ binary_to_list(Function) ++ "/configuration",
+    QParams = filter_undef([{"Qualifier", Qualifier}]),
+    lambda_request(Config, get, Path, undefined, QParams).
+
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionConfiguration.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% ListAliases
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_ListAliases.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec list_aliases(FunctionName    :: binary()) -> return_val().
+list_aliases(FunctionName) ->
+    list_aliases(FunctionName, undefined, undefined, undefined).
+
+-spec list_aliases(FunctionName    :: binary(),
+                   FunctionVersion :: binary() | undefined) -> return_val().
+list_aliases(FunctionName, FunctionVersion) ->
+    list_aliases(FunctionName, FunctionVersion, undefined, undefined).
+
+-spec list_aliases(FunctionName    :: binary(),
+                   FunctionVersion :: binary() | undefined,
+                   Marker          :: binary() | undefined,
+                   MaxItems        :: integer() | undefined) -> return_val().
+list_aliases(FunctionName, FunctionVersion, Marker, MaxItems) ->
+    list_aliases(FunctionName, FunctionVersion,
+                 Marker, MaxItems, default_config()).
+
+-spec list_aliases(FunctionName    :: binary(),
+                   FunctionVersion :: binary() | undefined,
+                   Marker          :: binary() | undefined,
+                   MaxItems        :: integer() | undefined,
+                   Config          :: aws_config()) -> return_val().
+list_aliases(FunctionName, FunctionVersion, Marker, MaxItems, Config) ->
+    Path = base_path() ++ "functions/"
+        ++ binary_to_list(FunctionName) ++ "/aliases",
+    QParams = filter_undef([{"Marker", Marker},
+                            {"MaxItems", MaxItems},
+                            {"FunctionVersion", FunctionVersion}]),
+    lambda_request(Config, get, Path, undefined, QParams).
+
+%%------------------------------------------------------------------------------
+%% ListEventSourceMappings
+%%------------------------------------------------------------------------------
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_ListEventSourceMappings.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec list_event_source_mappings(EventSourceArn :: binary(),
+                                 FunctionName   :: binary()) -> return_val().
+list_event_source_mappings(EventSourceArn, FunctionName) ->
+    list_event_source_mappings(EventSourceArn, FunctionName, undefined, undefined).
+
+-spec list_event_source_mappings(EventSourceArn :: binary(),
+                                 FunctionName   :: binary(),
+                                 Marker         :: binary() | undefined,
+                                 MaxItems       :: integer() | undefined) -> return_val().
+list_event_source_mappings(EventSourceArn, FunctionName, Marker, MaxItems) ->
+    list_event_source_mappings(EventSourceArn, FunctionName,
+                               Marker, MaxItems, default_config()).
+
+-spec list_event_source_mappings(EventSourceArn :: binary(),
+                                 FunctionName   :: binary(),
+                                 Marker         :: binary() | undefined,
+                                 MaxItems       :: integer() | undefined,
+                                 Config         :: aws_config()) -> return_val().
+list_event_source_mappings(EventSourceArn, FunctionName, Marker, MaxItems, Config) ->
+    Path = base_path() ++ "event-source-mappings/",
+    QParams = filter_undef([{"Marker", Marker},
+                            {"MaxItems", MaxItems},
+                            {"EventSourceArn", EventSourceArn},
+                            {"FunctionName", FunctionName}]),
+    lambda_request(Config, get, Path, undefined, QParams).
+
+%%------------------------------------------------------------------------------
+%% ListFunctions
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctions.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec list_functions() -> return_val().
+list_functions() ->
+    list_functions(undefined, undefined, default_config()).
+
+-spec list_functions(Marker   :: binary(),
+                     MaxItems :: integer()) -> return_val().
+list_functions(Marker, MaxItems) ->
+    list_functions(Marker, MaxItems, default_config()).
+
+-spec list_functions(Marker   :: binary(),
+                     MaxItems :: integer(),
+                     Config   :: aws_config()) -> return_val().
+list_functions(Marker, MaxItems, Config) ->
+    Path = base_path() ++ "functions/",
+    QParams = filter_undef([{"Marker", Marker},
+                            {"MaxItems", MaxItems}]),
+    lambda_request(Config, get, Path, undefined, QParams).
+
+%%------------------------------------------------------------------------------
+%% ListVersionsByFunction
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_ListVersionsByFunction.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+-spec list_versions_by_function(FunctionName :: binary()) -> return_val().
+list_versions_by_function(Function) ->
+    list_versions_by_function(Function, undefined, undefined).
+
+-spec list_versions_by_function(FunctionName :: binary(),
+                                Marker       :: binary() | undefined,
+                                MaxItems     :: integer() | undefined) -> return_val().
+list_versions_by_function(Function, Marker, MaxItems) ->
+    list_versions_by_function(Function, Marker, MaxItems, default_config()).
+
+-spec list_versions_by_function(FunctionName :: binary(),
+                                Marker       :: binary() | undefined,
+                                MaxItems     :: integer() | undefined,
+                                Config       :: aws_config()) -> return_val().
+list_versions_by_function(Function, Marker, MaxItems, Config) ->
+    Path = base_path() ++ "functions/" ++ binary_to_list(Function) ++ "/versions",
+    QParams = filter_undef([{"Marker", Marker},
+                            {"MaxItems", MaxItems}]),
+    lambda_request(Config, get, Path, undefined, QParams).
+
+
+%%------------------------------------------------------------------------------
+%% PublishVersion
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_PublishVersion.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+-spec publish_version(FunctionName :: binary()) -> return_val().
+publish_version(FunctionName) ->
+    publish_version(FunctionName, undefined, undefined).
+
+-spec publish_version(FunctionName :: binary(),
+                      CodeSha      :: binary() | undefined,
+                      Description  :: binary() | undefined) -> return_val().
+publish_version(FunctionName, CodeSha, Description) ->
+    publish_version(FunctionName, CodeSha, Description, default_config()).
+
+-spec publish_version(FunctionName :: binary(),
+                      CodeSha      :: binary() | undefined,
+                      Description  :: binary() | undefined,
+                      Config       :: aws_config()) -> return_val().
+publish_version(FunctionName, CodeSha, Description, Config) ->
+    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName) ++ "/versions",
+    Json = filter_undef([{<<"CodeSha">>, CodeSha},
+                         {<<"Description">>, Description}]),
+    lambda_request(Config, post, Path, Json).
+
+%%------------------------------------------------------------------------------
+%% UpdateAlias
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_UpdateAlias.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+-spec update_alias(FunctionName    :: binary(),
+                   AliasName       :: binary()) -> return_val().
+update_alias(FunctionName, AliasName) ->
+    update_alias(FunctionName, AliasName, undefined, undefined).
+
+-spec update_alias(FunctionName    :: binary(),
+                   AliasName       :: binary(),
+                   Description     :: binary() | undefined,
+                   FunctionVersion :: binary() | undefined) -> return_val().
+update_alias(FunctionName, AliasName, Description, FunctionVersion) ->
+    update_alias(FunctionName, AliasName,
+                 Description, FunctionVersion, default_config()).
+
+-spec update_alias(FunctionName    :: binary(),
+                   AliasName       :: binary(),
+                   Description     :: binary() | undefined,
+                   FunctionVersion :: binary() | undefined,
+                   Config          :: aws_config()) -> return_val().
+update_alias(FunctionName, AliasName, Description, FunctionVersion, Config) ->
+    Path = base_path() ++ "functions/"
+        ++ binary_to_list(FunctionName) ++ "/aliases/" ++ binary_to_list(AliasName),
+    Json = filter_undef([{"Description", Description},
+                         {"FunctionVersion", FunctionVersion}]),
+    lambda_request(Config, put, Path, Json).
+
+%%------------------------------------------------------------------------------
+%% UpdateEventSourceMapping
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_UpdateEventSourceMapping.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec update_event_source_mapping(Uuid         :: binary(),
+                                  BatchSize    :: integer() | undefined,
+                                  Enabled      :: boolean() | undefined,
+                                  FunctionName :: binary() | undefined) -> return_val().
+update_event_source_mapping(Uuid, BatchSize, Enabled, FunctionName) ->
+    update_event_source_mapping(Uuid, BatchSize, Enabled,
+                                FunctionName, default_config()).
+
+-spec update_event_source_mapping(Uuid         :: binary(),
+                                  BatchSize    :: integer() | undefined,
+                                  Enabled      :: boolean() | undefined,
+                                  FunctionName :: binary() | undefined,
+                                  Config       :: aws_config()) -> return_val().
+update_event_source_mapping(Uuid, BatchSize, Enabled, FunctionName, Config) ->
+    Path = base_path() ++ "event-source-mappings/" ++ binary_to_list(Uuid),
+    Json = filter_undef([{<<"BatchSize">>, BatchSize},
+                         {<<"Enabled">>, Enabled},
+                         {<<"FunctionName">>, FunctionName}]),
+    lambda_request(Config, put, Path, Json).
+
+%%------------------------------------------------------------------------------
+%% UpdateFunctionCode
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionCode.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+
+-spec update_function_code(FunctionName :: binary(),
+                           Publish      :: boolean(),
+                           Code         :: erlcloud_lambda_code()) -> return_val().
+update_function_code(FunctionName, Publish, Code) ->
+    update_function_code(FunctionName, Publish, Code, default_config()).
+
+-spec update_function_code(FunctionName :: binary(),
+                           Publish      :: boolean(),
+                           Code         :: erlcloud_lambda_code(),
+                           Config       :: aws_config()) -> return_val().
+update_function_code(FunctionName, Publish, Code, Config) ->
+    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName) ++ "/code",
+    Json = [{<<"Publish">>, Publish} | from_record(Code)],
+    lambda_request(Config, put, Path, Json).
+
+%%------------------------------------------------------------------------------
+%% UpdateFunctionConfiguration
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% Lambda API:
+%% [http://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionConfiguration.html]
+%%
+%% ===Example===
+%%
+%%------------------------------------------------------------------------------
+-spec update_function_configuration(FunctionName :: binary(),
+                                    Description  :: binary() | undefined,
+                                    Handler      :: binary() | undefined,
+                                    MemorySize   :: integer() | undefined,
+                                    Role         :: binary() | undefined,
+                                    Timeout      :: 1..300 | undefined) -> return_val().
+update_function_configuration(FunctionName, Description,
+                              Handler, MemorySize, Role, Timeout) ->
+    update_function_configuration(FunctionName, Description, Handler,
+                                  MemorySize, Role, Timeout, default_config()).
+
+
+-spec update_function_configuration(FunctionName :: binary(),
+                                    Description  :: binary() | undefined,
+                                    Handler      :: binary() | undefined,
+                                    MemorySize   :: integer() | undefined,
+                                    Role         :: binary() | undefined,
+                                    Timeout      :: 1..300 | undefined,
+                                    Config       :: aws_config()) -> return_val().
+update_function_configuration(FunctionName, Description, Handler,
+                              MemorySize, Role, Timeout, Config) ->
+    Path = base_path() ++ "functions/" ++ binary_to_list(FunctionName) ++ "/configuration",
+    Json = filter_undef([{<<"Description">>, Description},
+                         {<<"Handler">>, Handler},
+                         {<<"MemorySize">>, MemorySize},
+                         {<<"Role">>, Role},
+                         {<<"Timeout">>, Timeout}]),
+    lambda_request(Config, put, Path, Json).
+%%------------------------------------------------------------------------------
+%% Utility Functions
+%%------------------------------------------------------------------------------
+
+from_record(#erlcloud_lambda_code{s3Bucket        = S3Bucket,
+                                  s3Key           = S3Key,
+                                  s3ObjectVersion = S3ObjectVersion,
+                                  zipFile         = ZipFile}) ->
+    List = [{<<"S3Bucket">>, S3Bucket},
+            {<<"S3Key">>, S3Key},
+            {<<"S3ObjectVersion">>, S3ObjectVersion},
+            {<<"ZipFile">>, ZipFile}],
+    filter_undef(List).
+
+filter_undef(List) ->
+    lists:filter(fun({_Name, Value}) -> Value =/= undefined end, List).
+
+base_path() ->
+    "/" ++ ?API_VERSION ++ "/".
+
+lambda_request(Config, Method, Path, Body) ->
+    lambda_request(Config, Method, Path, Body, []).
+
+lambda_request(Config, Method, Path, Body, QParam) ->
+    case erlcloud_aws:update_config(Config) of
+        {ok, Config1} ->
+            lambda_request_no_update(Config1, Method, Path, Body, QParam);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+lambda_request_no_update(Config, Method, Path, Body, QParam) ->
+    Form = case encode_body(Body) of
+               <<>>   -> erlcloud_http:make_query_string(QParam);
+               Value  -> Value
+           end,
+    Headers = headers(Method, Path, Config, encode_body(Body), QParam),
+    case erlcloud_aws:aws_request_form_raw(
+           Method, Config#aws_config.lambda_scheme, Config#aws_config.lambda_host,
+           Config#aws_config.lambda_port, Path, Form, Headers, Config) of
+        {ok, Data} ->
+            {ok, jsx:decode(Data)};
+        E ->
+            E
+    end.
+
+encode_body(undefined) ->
+    <<>>;
+encode_body([]) ->
+    <<"{}">>;
+encode_body(Body) ->
+    jsx:encode(Body).
+
+headers(Method, Uri, Config, Body, QParam) ->
+    Headers = [{"host", Config#aws_config.lambda_host},
+               {"content-type", "application/json"}],
+    Region = erlcloud_aws:aws_region_from_host(Config#aws_config.lambda_host),
+    erlcloud_aws:sign_v4(Method, Uri, Config,
+                         Headers, Body, Region, "lambda", QParam).

--- a/test/erlcloud_lambda_tests.erl
+++ b/test/erlcloud_lambda_tests.erl
@@ -1,0 +1,780 @@
+-module(erlcloud_lambda_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include_lib("erlcloud/include/erlcloud_lambda.hrl").
+
+-define(BASE_URL, "https://lambda.us-east-1.amazonaws.com:443/2015-03-31/").
+
+route53_test_() ->
+    {foreach,
+     fun setup/0,
+     fun meck:unload/1,
+     [
+      fun api_tests/1
+     ]}.
+
+mocks() ->
+    [
+     mocked_create_alias(),
+     mocked_create_event_source_mapping(),
+     mocked_create_function(),
+     mocked_delete_event_source_mapping(),
+     mocked_get_alias(),
+     mocked_get_event_source_mapping(),
+     mocked_get_function(),
+     mocked_get_function_configuration(),
+     mocked_list_aliases(),
+     mocked_list_event_source_mappings(),
+     mocked_list_function(),
+     mocked_list_versions_by_function(),
+     mocked_publish_version(),
+     mocked_update_alias(),
+     mocked_update_event_source_mapping(),
+     mocked_update_function_code(),
+     mocked_update_function_configuration()
+    ].
+
+setup() ->
+    Config = #aws_config{access_key_id="AccessId",
+                         secret_access_key="secret",
+                         security_token="token"},
+    meck:new(ECA = erlcloud_aws, [non_strict, passthrough]),
+    meck:expect(ECA, default_config, 0, Config),
+    meck:expect(ECA, update_config, 1, {ok, Config}),
+    meck:new(ECH = erlcloud_httpc),
+    meck:expect(ECH, request, mocks()),
+    [ECA, ECH].
+
+mocked_create_alias() ->
+    {
+      [?BASE_URL ++ "functions/name/aliases", post, '_',
+       <<"{\"FunctionVersion\":\"$LATEST\",\"Name\":\"aliasName1\"}">>, '_', '_'],
+      make_response(<<"{\"AliasArn\":\"arn:aws:lambda:us-east-1:352283894008:"
+"function:name:aliasName1\",\"Description\":\"\",\"FunctionVersion\":\"$LATEST"
+"\",\"Name\":\"aliasName1\"}">>)
+    }.
+
+mocked_create_event_source_mapping() ->
+    {
+      [?BASE_URL ++ "event-source-mappings", post, '_',
+       <<"{\"EventSourceArn\":\"arn:aws:kinesis:us-east-1:352283894008:stream"
+         "/eholland-test\",\"FunctionName\":\"name\",\"StartingPosition\":\"TRI"
+         "M_HORIZON\"}">>, '_', '_'],
+      make_response(<<"{\"BatchSize\":100,\"EventSourceArn\":\"arn:aws:kinesi"
+"s:us-east-1:352283894008:stream/eholland-test\",\"FunctionArn\":\"arn:aws:lam"
+"bda:us-east-1:352283894008:function:name\",\"LastModified\":1449845416.123,\""
+"LastProcessingResult\":\"No records processed\",\"State\":\"Creating\",\"Stat"
+"eTransitionReason\":\"User action\",\"UUID\":\"3f303f86-7395-43f3-9902-f5c80f"
+"0a5382\"}">>)
+    }.
+
+mocked_create_function() ->
+    {
+      [?BASE_URL ++ "functions", post, '_',
+       <<"{\"Code\":{\"S3Bucket\":\"bi-lambda\",\"S3Key\":\"local_transform/bi-a"
+"ssets-environment-create-environment_1-0-0_latest.zip\"},\"FunctionName\":\"name"
+"\",\"Handler\":\"index.process\",\"Role\":\"arn:aws:iam::352283894008:role/lambd"
+"a_basic_execution\",\"Runtime\":\"nodejs\"}">> , '_', '_'],
+      make_response(<<"{\"CodeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4Ic"
+"piPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"FunctionArn\":\"arn:aws:la"
+"mbda:us-east-1:352283894008:function:name3\",\"FunctionName\":\"name3\",\"Han"
+"dler\":\"index.process\",\"LastModified\":\"2015-12-11T13:45:31.924+0000\",\""
+"MemorySize\":128,\"Role\":\"arn:aws:iam::352283894008:role/lambda_basic_execu"
+"tion\",\"Runtime\":\"nodejs\",\"Timeout\":3,\"Version\":\"$LATEST\",\"VpcConf"
+"ig\":null}">>)
+    }.
+mocked_delete_event_source_mapping() ->
+    {
+      [?BASE_URL ++ "event-source-mappings/6554f300-551b-46a6-829c-41b6af6022c6?",
+       delete, '_', <<>>, '_', '_'],
+      make_response(<<"{\"BatchSize\":100,\"EventSourceArn\":\"arn:aws:kinesi"
+"s:us-east-1:352283894008:stream/eholland-test\",\"FunctionArn\":\"arn:aws:lam"
+"bda:us-east-1:352283894008:function:name\",\"LastModified\":1449843960.0,\"La"
+"stProcessingResult\":\"No records processed\",\"State\":\"Deleting\",\"StateT"
+"ransitionReason\":\"User action\",\"UUID\":\"a45b58ec-a539-4c47-929e-174b4dd2"
+"d963\"}">>)
+    }.
+mocked_get_alias() ->
+        {
+      [?BASE_URL ++ "functions/name/aliases/aliasName?",
+       get, '_', <<>>, '_', '_'],
+      make_response(<<"{\"AliasArn\":\"arn:aws:lambda:us-east-1:352283894008:"
+"function:name:aliasName\",\"Description\":\"\",\"FunctionVersion\":\"$LATEST\"
+"",\"Name\":\"aliasName\"}">>)
+    }.
+mocked_get_event_source_mapping() ->
+        {
+      [?BASE_URL ++ "event-source-mappings/a45b58ec-a539-4c47-929e-174b4dd2d963?",
+       get, '_', <<>>, '_', '_'],
+      make_response(<<"{\"BatchSize\":100,\"EventSourceArn\":\"arn:aws:kinesi"
+"s:us-east-1:352283894008:stream/eholland-test\",\"FunctionArn\":\"arn:aws:lam"
+"bda:us-east-1:352283894008:function:name\",\"LastModified\":1449841860.0,\"La"
+"stProcessingResult\":\"No records processed\",\"State\":\"Enabled\",\"StateTr"
+"ansitionReason\":\"User action\",\"UUID\":\"a45b58ec-a539-4c47-929e-174b4dd2d"
+"963\"}">>)
+    }.
+mocked_get_function() ->
+    {
+      [?BASE_URL ++ "functions/name?",
+       get, '_', <<>>, '_', '_'],
+      make_response(<<"{\"Code\":{\"Location\":\"https://awslambda-us-east-1-"
+"tasks.s3-us-east-1.amazonaws.com/snapshots/352283894008/name-69237aec-bae9-40"
+"86-af73-a6610c2f8eb8?x-amz-security-token=AQoDYXdzENb%2F%2F%2F%2F%2F%2F%2F%2F"
+"%2F%2FwEa4APJSJNHsYWnObKlElri5ytVzNg0t%2F0zwADHn40jy%2F1ZDW9%2FYWGi8dTp1l6LWB"
+"I9TwJi0LLcgp%2FlCxJIh7hsAPftYX62J9r9lRcmgd9RnYssg1%2Fkpfyjya90epxKg2zdHm%2BuZ"
+"GukHYDcmAE1IQcHwsaQbvGAjXPCpFyxClbV6gMcFIsaBtfMxoMcbTCXG9m8l56nKgcX6Mi60vRNaB"
+"83AeNVrKMhB8EBUUbYbaB%2BG0iJg32i2HBF6VJMxamOLIEf1GJp1tWt%2FSAHfEkdTwcwtGINH3T"
+"NRv%2BY3ddsXs8pJ49eY49NCHANPC%2Bq0JzNQydbIK1shz8w1nozXYQo6%2BNh9tqOlaJNFgfFbt"
+"JkUDXv4rFqgVsfgJKJSQBeYUKmlNvIPQIoHWhRjjRzQUGmYDc3eEug7vELsNcHZixI4nNVycH%2BJ"
+"ZwaBvswy4eE7gBv3HwHi3SVlg9iXFTrfWTK%2FlCybC7mZIjAmPGiLCG5Pu8SoCgaGdHp8HmSeXXu"
+"s4VUFcVTUw1qn7E%2BSaRFg3MTpCdu1f1Nqh4pNu7GpZacyLbH%2BSocuPyTjyYGL8sk0C3rjIWZi"
+"pJcfUZsleS1cXLEGw%2FPAK5eg0RNWlVsaF1WgVimqQh3LtoRZ%2BwYCHRXsHjhCyQ8VhoguJCrsw"
+"U%3D&AWSAccessKeyId=ASIAIAUY4IMA6JRJ3FSA&Expires=1449843004&Signature=5KUmber"
+"1cOBSChlKtnLaI%2FUemU4%3D\",\"RepositoryType\":\"S3\"},\"Configuration\":{\"C"
+"odeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=\",\"CodeSize\":848"
+",\"Description\":\"\",\"FunctionArn\":\"arn:aws:lambda:us-east-1:352283894008"
+":function:name\",\"FunctionName\":\"name\",\"Handler\":\"index.process\",\"La"
+"stModified\":\"2015-12-10T13:57:48.214+0000\",\"MemorySize\":512,\"Role\":\"a"
+"rn:aws:iam::352283894008:role/lambda_kinesis_role\",\"Runtime\":\"nodejs\",\""
+"Timeout\":30,\"Version\":\"$LATEST\",\"VpcConfig\":null}}">>)
+    }.
+mocked_get_function_configuration() ->
+    {
+      [?BASE_URL ++ "functions/name/configuration?", get, '_', <<>>, '_', '_'],
+      make_response(<<"{\"CodeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4Ic"
+"piPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"FunctionArn\":\"arn:aws:la"
+"mbda:us-east-1:352283894008:function:name\",\"FunctionName\":\"name\",\"Handl"
+"er\":\"index.process\",\"LastModified\":\"2015-12-10T13:57:48.214+0000\",\"Me"
+"morySize\":512,\"Role\":\"arn:aws:iam::352283894008:role/lambda_kinesis_role\"
+"",\"Runtime\":\"nodejs\",\"Timeout\":30,\"Version\":\"$LATEST\",\"VpcConfig\""
+":null}">>)
+    }.
+
+mocked_list_aliases() ->
+    {
+      [?BASE_URL ++ "functions/name/aliases?", get, '_', <<>>, '_', '_'],
+      make_response(<<"{\"Aliases\":[{\"AliasArn\":\"arn:aws:lambda:us-east-1"
+":352283894008:function:name:aliasName\",\"Description\":\"\",\"FunctionVersio"
+"n\":\"$LATEST\",\"Name\":\"aliasName\"},{\"AliasArn\":\"arn:aws:lambda:us-eas"
+"t-1:352283894008:function:name:aliasName1\",\"Description\":\"\",\"FunctionVe"
+"rsion\":\"$LATEST\",\"Name\":\"aliasName1\"}],\"NextMarker\":null}">>)
+    }.
+
+mocked_list_event_source_mappings() ->
+    {
+      [?BASE_URL ++ "event-source-mappings/?EventSourceArn=arn%3Aaws%3Akinesis%"
+       "3Aus-east-1%3A352283894008%3Astream%2Feholland-test&FunctionName=name",
+       get, '_', <<>>, '_', '_'],
+      make_response(<<"{\"EventSourceMappings\":[{\"BatchSize\":100,\"EventSo"
+"urceArn\":\"arn:aws:kinesis:us-east-1:352283894008:stream/eholland-test\",\"F"
+"unctionArn\":\"arn:aws:lambda:us-east-1:352283894008:function:name\",\"LastMo"
+"dified\":1449841860.0,\"LastProcessingResult\":\"No records processed\",\"Sta"
+"te\":\"Enabled\",\"StateTransitionReason\":\"User action\",\"UUID\":\"a45b58e"
+"c-a539-4c47-929e-174b4dd2d963\"}],\"NextMarker\":null}">>)
+    }.
+
+mocked_list_function() ->
+    {
+      [?BASE_URL ++ "functions/?",
+       get, '_', <<>>, '_', '_'],
+      make_response(<<"{\"Functions\":[{\"CodeSha256\":\"XmLDAZXEkl5KbA8ezZpw"
+"FU+bjgTXBehUmWGOScl4F2A=\",\"CodeSize\":5561,\"Description\":\"\",\"FunctionA"
+"rn\":\"arn:aws:lambda:us-east-1:352283894008:function:bi-assets-asset-create-"
+"host\",\"FunctionName\":\"bi-assets-asset-create-host\",\"Handler\":\"index.h"
+"andler\",\"LastModified\":\"2015-11-27T09:55:12.973+0000\",\"MemorySize\":128"
+",\"Role\":\"arn:aws:iam::352283894008:role/lambda_basic_execution\",\"Runtime"
+"\":\"nodejs\",\"Timeout\":3,\"Version\":\"$LATEST\",\"VpcConfig\":null},{\"Co"
+"deSha256\":\"XmLDAZXEkl5KbA8ezZpwFU+bjgTXBehUmWGOScl4F2A=\",\"CodeSize\":5561"
+",\"Description\":\"\",\"FunctionArn\":\"arn:aws:lambda:us-east-1:352283894008"
+":function:bi-assets-asset-create-host1\",\"FunctionName\":\"bi-assets-asset-c"
+"reate-host1\",\"Handler\":\"index.handler\",\"LastModified\":\"2015-12-01T11:"
+"20:44.464+0000\",\"MemorySize\":128,\"Role\":\"arn:aws:iam::352283894008:role"
+"/lambda_kinesis_role\",\"Runtime\":\"nodejs\",\"Timeout\":10,\"Version\":\"$L"
+"ATEST\",\"VpcConfig\":null},{\"CodeSha256\":\"tZJ+kUZVD1vGYwMIUvAoaZmvS4I9NHV"
+"c7a/267eChYY=\",\"CodeSize\":132628,\"Description\":\"\",\"FunctionArn\":\"ar"
+"n:aws:lambda:us-east-1:352283894008:function:bi-driver\",\"FunctionName\":\"b"
+"i-driver\",\"Handler\":\"index.handler\",\"LastModified\":\"2015-12-03T13:59:"
+"05.219+0000\",\"MemorySize\":1024,\"Role\":\"arn:aws:iam::352283894008:role/l"
+"ambda_kinesis_role\",\"Runtime\":\"nodejs\",\"Timeout\":59,\"Version\":\"$LAT"
+"EST\",\"VpcConfig\":null},{\"CodeSha256\":\"QS10seyYGXrrhAnGMbJcTi+JOa4HWLaD+"
+"9YCLYG3+VE=\",\"CodeSize\":121486,\"Description\":\"An Amazon Kinesis stream "
+"processor that logs the data being published.\",\"FunctionArn\":\"arn:aws:lam"
+"bda:us-east-1:352283894008:function:eholland-js-router\",\"FunctionName\":\"e"
+"holland-js-router\",\"Handler\":\"index.handler\",\"LastModified\":\"2015-12-"
+"02T14:50:41.923+0000\",\"MemorySize\":1024,\"Role\":\"arn:aws:iam::3522838940"
+"08:role/lambda_kinesis_role\",\"Runtime\":\"nodejs\",\"Timeout\":60,\"Version"
+"\":\"$LATEST\",\"VpcConfig\":null},{\"CodeSha256\":\"ey+6CSWe750XoPSdVSQditxx"
+"oHNWmPFwve/MLPNs/Do=\",\"CodeSize\":253,\"Description\":\"\",\"FunctionArn\":"
+"\"arn:aws:lambda:us-east-1:352283894008:function:eholland-test-aims-user\",\""
+"FunctionName\":\"eholland-test-aims-user\",\"Handler\":\"lambda_function.lamb"
+"da_handler\",\"LastModified\":\"2015-11-09T17:32:46.030+0000\",\"MemorySize\""
+":128,\"Role\":\"arn:aws:iam::352283894008:role/lambda_basic_execution\",\"Run"
+"time\":\"python2.7\",\"Timeout\":3,\"Version\":\"$LATEST\",\"VpcConfig\":null"
+"},{\"CodeSha256\":\"R9HaKKCPPAem0ikKrkMGpDtX95M8egDCDd+4Ws+Kk5c=\",\"CodeSize"
+"\":253,\"Description\":\"aims users transform function\",\"FunctionArn\":\"ar"
+"n:aws:lambda:us-east-1:352283894008:function:eholland-test-aims-users\",\"Fun"
+"ctionName\":\"eholland-test-aims-users\",\"Handler\":\"lambda_function.lambda"
+"_handler\",\"LastModified\":\"2015-11-02T13:59:32.509+0000\",\"MemorySize\":1"
+"28,\"Role\":\"arn:aws:iam::352283894008:role/lambda_basic_execution\",\"Runti"
+"me\":\"python2.7\",\"Timeout\":3,\"Version\":\"$LATEST\",\"VpcConfig\":null},"
+"{\"CodeSha256\":\"PGG1vCAQpc8J7e4HL1z1Pv4DGSZEmhnJaNPTGDS29kk=\",\"CodeSize\""
+":32372,\"Description\":\"An Amazon Kinesis stream processor that logs the dat"
+"a being published.\",\"FunctionArn\":\"arn:aws:lambda:us-east-1:352283894008:"
+"function:eholland-test-router\",\"FunctionName\":\"eholland-test-router\",\"H"
+"andler\":\"ProcessKinesisRecords.lambda_handler\",\"LastModified\":\"2015-11-"
+"09T10:58:50.458+0000\",\"MemorySize\":256,\"Role\":\"arn:aws:iam::35228389400"
+"8:role/lambda_kinesis_role\",\"Runtime\":\"python2.7\",\"Timeout\":59,\"Versi"
+"on\":\"$LATEST\",\"VpcConfig\":null},{\"CodeSha256\":\"8twXwGaAXyr8Li81rGhM6v"
+"lMh+dvXglwqgIshfaio+U=\",\"CodeSize\":708740,\"Description\":\"Lambda Router "
+"Function for ETL Service\",\"FunctionArn\":\"arn:aws:lambda:us-east-1:3522838"
+"94008:function:us-east-1_base_eholland_master_lambda_route\",\"FunctionName\""
+":\"us-east-1_base_eholland_master_lambda_route\",\"Handler\":\"ProcessKinesis"
+"Records.handler\",\"LastModified\":\"2015-11-11T10:13:19.043+0000\",\"MemoryS"
+"ize\":512,\"Role\":\"arn:aws:iam::352283894008:role/lambda_kinesis_role\",\"R"
+"untime\":\"nodejs\",\"Timeout\":59,\"Version\":\"$LATEST\",\"VpcConfig\":null"
+"},{\"CodeSha256\":\"aDwLJhljsMVHsaN+LM4jRmsSLKKBdS+eFrAhKmJ/zbQ=\",\"CodeSize"
+"\":253,\"Description\":\"\",\"FunctionArn\":\"arn:aws:lambda:us-east-1:352283"
+"894008:function:us-east-1_base_eholland_master_lambda_route-aims-user-create\""
+",\"FunctionName\":\"us-east-1_base_eholland_master_lambda_route-aims-user-cr"
+"eate\",\"Handler\":\"lambda_function.lambda_handler\",\"LastModified\":\"2015"
+"-11-11T09:42:10.303+0000\",\"MemorySize\":128,\"Role\":\"arn:aws:iam::3522838"
+"94008:role/lambda_basic_execution\",\"Runtime\":\"python2.7\",\"Timeout\":3,"
+"\"Version\":\"$LATEST\",\"VpcConfig\":null},{\"CodeSha256\":\"zeoBX1hIWJBHk1mu"
+"Je1iFyS1CcAmsT0Ct4IcpiPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"Functi"
+"onArn\":\"arn:aws:lambda:us-east-1:352283894008:function:name\",\"FunctionNam"
+"e\":\"name\",\"Handler\":\"index.process\",\"LastModified\":\"2015-12-10T13:5"
+"7:48.214+0000\",\"MemorySize\":512,\"Role\":\"arn:aws:iam::352283894008:role/"
+"lambda_kinesis_role\",\"Runtime\":\"nodejs\",\"Timeout\":30,\"Version\":\"$LA"
+"TEST\",\"VpcConfig\":null},{\"CodeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0C"
+"t4IcpiPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"FunctionArn\":\"arn:aw"
+"s:lambda:us-east-1:352283894008:function:name2\",\"FunctionName\":\"name2\","
+"\"Handler\":\"index.process\",\"LastModified\":\"2015-12-10T11:31:21.106+0000"
+"\",\"MemorySize\":128,\"Role\":\"arn:aws:iam::352283894008:role/lambda_basic_e"
+"xecution\",\"Runtime\":\"nodejs\",\"Timeout\":3,\"Version\":\"$LATEST\",\"Vpc"
+"Config\":null}],\"NextMarker\":null}">>)
+    }.
+
+mocked_list_versions_by_function() ->
+    {
+      [?BASE_URL ++ "functions/name/versions?", get, '_', <<>>, '_', '_'],
+      make_response(<<"{\"NextMarker\":null,\"Versions\":[{\"CodeSha256\":\"z"
+"eoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=\",\"CodeSize\":848,\"Description"
+"\":\"\",\"FunctionArn\":\"arn:aws:lambda:us-east-1:352283894008:function:name:"
+"$LATEST\",\"FunctionName\":\"name\",\"Handler\":\"index.process\",\"LastModif"
+"ied\":\"2015-12-10T13:57:48.214+0000\",\"MemorySize\":512,\"Role\":\"arn:aws:"
+"iam::352283894008:role/lambda_kinesis_role\",\"Runtime\":\"nodejs\",\"Timeout"
+"\":30,\"Version\":\"$LATEST\",\"VpcConfig\":null},{\"CodeSha256\":\"zeoBX1hIW"
+"JBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=\",\"CodeSize\":848,\"Description\":\"\","
+"\"FunctionArn\":\"arn:aws:lambda:us-east-1:352283894008:function:name:1\",\"Fu"
+"nctionName\":\"name\",\"Handler\":\"index.process\",\"LastModified\":\"2015-1"
+"2-10T11:36:12.776+0000\",\"MemorySize\":128,\"Role\":\"arn:aws:iam::352283894"
+"008:role/lambda_kinesis_role\",\"Runtime\":\"nodejs\",\"Timeout\":3,\"Version"
+"\":\"1\",\"VpcConfig\":null},{\"CodeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT"
+"0Ct4IcpiPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"FunctionArn\":\"arn:"
+"aws:lambda:us-east-1:352283894008:function:name:2\",\"FunctionName\":\"name\""
+",\"Handler\":\"index.process\",\"LastModified\":\"2015-12-10T13:56:43.171+000"
+"0\",\"MemorySize\":128,\"Role\":\"arn:aws:iam::352283894008:role/lambda_kines"
+"is_role\",\"Runtime\":\"nodejs\",\"Timeout\":3,\"Version\":\"2\",\"VpcConfig"
+"\":null}]}">>)
+    }.
+
+mocked_publish_version() ->
+    {
+      [?BASE_URL ++ "functions/name/versions", post, '_', <<"{}">>, '_', '_'],
+      make_response(<<"{\"CodeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4Ic"
+"piPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"FunctionArn\":\"arn:aws:la"
+"mbda:us-east-1:352283894008:function:name:3\",\"FunctionName\":\"name\",\"Han"
+"dler\":\"index.process\",\"LastModified\":\"2015-12-10T13:57:48.214+0000\",\""
+"MemorySize\":512,\"Role\":\"arn:aws:iam::352283894008:role/lambda_kinesis_rol"
+"e\",\"Runtime\":\"nodejs\",\"Timeout\":30,\"Version\":\"3\",\"VpcConfig\":nul"
+"l}">>)
+    }.
+
+mocked_update_alias() ->
+    {
+      [?BASE_URL ++ "functions/name/aliases/aliasName", put,
+       '_', <<"{}">>, '_', '_'],
+      make_response(<<"{\"AliasArn\":\"arn:aws:lambda:us-east-1:352283894008:"
+"function:name:aliasName\",\"Description\":\"\",\"FunctionVersion\":\"$LATEST"
+"\",\"Name\":\"aliasName\"}">>)
+    }.
+mocked_update_event_source_mapping() ->
+    {
+      [?BASE_URL ++ "event-source-mappings/a45b58ec-a539-4c47-929e-174b4dd2d963",
+       put, '_', <<"{\"BatchSize\":100}">>, '_', '_'],
+      make_response(<<"{\"BatchSize\":100,\"EventSourceArn\":\"arn:aws:kinesi"
+"s:us-east-1:352283894008:stream/eholland-test\",\"FunctionArn\":\"arn:aws:lam"
+"bda:us-east-1:352283894008:function:name\",\"LastModified\":1449844011.991,\""
+"LastProcessingResult\":\"No records processed\",\"State\":\"Updating\",\"Stat"
+"eTransitionReason\":\"User action\",\"UUID\":\"a45b58ec-a539-4c47-929e-174b4d"
+"d2d963\"}">>)
+    }.
+
+mocked_update_function_code() ->
+    {
+      [?BASE_URL ++ "functions/name/code", put, '_',
+       <<"{\"Publish\":true,\"S3Bucket\":\"bi-lambda\",\"S3Key\":\"local_transf"
+         "orm/bi-assets-environment-create-environment_1-0-0_latest.zip\"}">>,
+       '_', '_'],
+      make_response(<<"{\"CodeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4Ic"
+"piPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"FunctionArn\":\"arn:aws:la"
+"mbda:us-east-1:352283894008:function:name:4\",\"FunctionName\":\"name\",\"Han"
+"dler\":\"index.process\",\"LastModified\":\"2015-12-11T14:29:17.023+0000\",\""
+"MemorySize\":512,\"Role\":\"arn:aws:iam::352283894008:role/lambda_kinesis_rol"
+"e\",\"Runtime\":\"nodejs\",\"Timeout\":30,\"Version\":\"4\",\"VpcConfig\":nul"
+"l}">>)
+    }.
+mocked_update_function_configuration() ->
+    {
+      [?BASE_URL ++ "functions/name/configuration", put, '_',
+       <<"{\"MemorySize\":512,\"Timeout\":30}">>, '_', '_'],
+      make_response(<<"{\"CodeSha256\":\"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4Ic"
+"piPf8QM=\",\"CodeSize\":848,\"Description\":\"\",\"FunctionArn\":\"arn:aws:la"
+"mbda:us-east-1:352283894008:function:name\",\"FunctionName\":\"name\",\"Handl"
+"er\":\"index.process\",\"LastModified\":\"2015-12-11T14:31:52.034+0000\",\"Me"
+"morySize\":512,\"Role\":\"arn:aws:iam::352283894008:role/lambda_kinesis_role\"
+"",\"Runtime\":\"nodejs\",\"Timeout\":30,\"Version\":\"$LATEST\",\"VpcConfig\""
+":null}">>)
+    }.
+
+api_tests(_) ->
+    [
+     fun() ->
+             Result   = erlcloud_lambda:list_functions(),
+             Expected =
+                 {ok,
+                  [{<<"Functions">>,
+                    [[{<<"CodeSha256">>,<<"XmLDAZXEkl5KbA8ezZpwFU+bjgTXBehUmWGOScl4F2A=">>},
+                      {<<"CodeSize">>,5561},
+                      {<<"Description">>,<<>>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:bi-assets-asset-create-host">>},
+                      {<<"FunctionName">>,<<"bi-assets-asset-create-host">>},
+                      {<<"Handler">>,<<"index.handler">>},
+                      {<<"LastModified">>,<<"2015-11-27T09:55:12.973+0000">>},
+                      {<<"MemorySize">>,128},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_basic_execution">>},
+                      {<<"Runtime">>,<<"nodejs">>},
+                      {<<"Timeout">>,3},{<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"XmLDAZXEkl5KbA8ezZpwFU+bjgTXBehUmWGOScl4F2A=">>},
+                      {<<"CodeSize">>,5561},
+                      {<<"Description">>,<<>>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:bi-assets-asset-create-host1">>},
+                      {<<"FunctionName">>,<<"bi-assets-asset-create-host1">>},
+                      {<<"Handler">>,<<"index.handler">>},
+                      {<<"LastModified">>,<<"2015-12-01T11:20:44.464+0000">>},
+                      {<<"MemorySize">>,128},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                      {<<"Runtime">>,<<"nodejs">>},
+                      {<<"Timeout">>,10},
+                      {<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"tZJ+kUZVD1vGYwMIUvAoaZmvS4I9NHVc7a/267eChYY=">>},
+                      {<<"CodeSize">>,132628},
+                      {<<"Description">>,<<>>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:bi-driver">>},
+                      {<<"FunctionName">>,<<"bi-driver">>},
+                      {<<"Handler">>,<<"index.handler">>},
+                      {<<"LastModified">>,<<"2015-12-03T13:59:05.219+0000">>},
+                      {<<"MemorySize">>,1024},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                      {<<"Runtime">>,<<"nodejs">>},
+                      {<<"Timeout">>,59},{<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"QS10seyYGXrrhAnGMbJcTi+JOa4HWLaD+9YCLYG3+VE=">>},
+                      {<<"CodeSize">>,121486},
+                      {<<"Description">>,<<"An Amazon Kinesis stream processor that logs the data being published.">>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:eholland-js-router">>},
+                      {<<"FunctionName">>,<<"eholland-js-router">>},
+                      {<<"Handler">>,<<"index.handler">>},
+                      {<<"LastModified">>,<<"2015-12-02T14:50:41.923+0000">>},
+                      {<<"MemorySize">>,1024},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                      {<<"Runtime">>,<<"nodejs">>},
+                      {<<"Timeout">>,60},
+                      {<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"ey+6CSWe750XoPSdVSQditxxoHNWmPFwve/MLPNs/Do=">>},
+                      {<<"CodeSize">>,253},
+                      {<<"Description">>,<<>>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:eholland-test-aims-user">>},
+                      {<<"FunctionName">>,<<"eholland-test-aims-user">>},
+                      {<<"Handler">>,<<"lambda_function.lambda_handler">>},
+                      {<<"LastModified">>,<<"2015-11-09T17:32:46.030+0000">>},
+                      {<<"MemorySize">>,128},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_basic_execution">>},
+                      {<<"Runtime">>,<<"python2.7">>},
+                      {<<"Timeout">>,3},
+                      {<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"R9HaKKCPPAem0ikKrkMGpDtX95M8egDCDd+4Ws+Kk5c=">>},
+                      {<<"CodeSize">>,253},
+                      {<<"Description">>,<<"aims users transform function">>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:eholland-test-aims-users">>},
+                      {<<"FunctionName">>,<<"eholland-test-aims-users">>},
+                      {<<"Handler">>,<<"lambda_function.lambda_handler">>},
+                      {<<"LastModified">>,<<"2015-11-02T13:59:32.509+0000">>},
+                      {<<"MemorySize">>,128},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_basic_execution">>},
+                      {<<"Runtime">>,<<"python2.7">>},
+                      {<<"Timeout">>,3},
+                      {<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"PGG1vCAQpc8J7e4HL1z1Pv4DGSZEmhnJaNPTGDS29kk=">>},
+                      {<<"CodeSize">>,32372},
+                      {<<"Description">>,<<"An Amazon Kinesis stream processor that logs the data being published.">>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:eholland-test-router">>},
+                      {<<"FunctionName">>,<<"eholland-test-router">>},
+                      {<<"Handler">>,<<"ProcessKinesisRecords.lambda_handler">>},
+                      {<<"LastModified">>,<<"2015-11-09T10:58:50.458+0000">>},
+                      {<<"MemorySize">>,256},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                      {<<"Runtime">>,<<"python2.7">>},
+                      {<<"Timeout">>,59},
+                      {<<"Version">>, <<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"8twXwGaAXyr8Li81rGhM6vlMh+dvXglwqgIshfaio+U=">>},
+                      {<<"CodeSize">>,708740},
+                      {<<"Description">>,<<"Lambda Router Function for ETL Service">>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:us-east-1_base_eholland_master_lambda_route">>},
+                      {<<"FunctionName">>,<<"us-east-1_base_eholland_master_lambda_route">>},
+                      {<<"Handler">>,<<"ProcessKinesisRecords.handler">>},
+                      {<<"LastModified">>,<<"2015-11-11T10:13:19.043+0000">>},
+                      {<<"MemorySize">>,512},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                      {<<"Runtime">>,<<"nodejs">>},
+                      {<<"Timeout">>,59},
+                      {<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"aDwLJhljsMVHsaN+LM4jRmsSLKKBdS+eFrAhKmJ/zbQ=">>},
+                      {<<"CodeSize">>,253},
+                      {<<"Description">>,<<>>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:us-east-1_base_eholland_master_lambda_route-aims-user-create">>},
+                      {<<"FunctionName">>,<<"us-east-1_base_eholland_master_lambda_route-aims-user-create">>},
+                      {<<"Handler">>,<<"lambda_function.lambda_handler">>},
+                      {<<"LastModified">>,<<"2015-11-11T09:42:10.303+0000">>},
+                      {<<"MemorySize">>,128},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_basic_execution">>},
+                      {<<"Runtime">>,<<"python2.7">>},
+                      {<<"Timeout">>,3},
+                      {<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                      {<<"CodeSize">>,848},
+                      {<<"Description">>,<<>>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                      {<<"FunctionName">>,<<"name">>},
+                      {<<"Handler">>,<<"index.process">>},
+                      {<<"LastModified">>,<<"2015-12-10T13:57:48.214+0000">>},
+                      {<<"MemorySize">>,512},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                      {<<"Runtime">>,<<"nodejs">>},
+                      {<<"Timeout">>,30},
+                      {<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}],
+                     [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                      {<<"CodeSize">>,848},
+                      {<<"Description">>,<<>>},
+                      {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name2">>},
+                      {<<"FunctionName">>,<<"name2">>},
+                      {<<"Handler">>,<<"index.process">>},
+                      {<<"LastModified">>,<<"2015-12-10T11:31:21.106+0000">>},
+                      {<<"MemorySize">>,128},
+                      {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_basic_execution">>},
+                      {<<"Runtime">>,<<"nodejs">>},
+                      {<<"Timeout">>,3},
+                      {<<"Version">>,<<"$LATEST">>},
+                      {<<"VpcConfig">>,null}]]},
+                   {<<"NextMarker">>,null}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:create_alias(<<"name">>, <<"$LATEST">>,
+                                                   <<"aliasName1">>, []),
+             Expected = {ok,[{<<"AliasArn">>,
+                              <<"arn:aws:lambda:us-east-1:352283894008:function:name:aliasName1">>},
+                             {<<"Description">>,<<>>},
+                             {<<"FunctionVersion">>,<<"$LATEST">>},
+                             {<<"Name">>,<<"aliasName1">>}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:create_event_source_mapping(
+                        <<"arn:aws:kinesis:us-east-1:352283894008:stream/eholland-test">>,
+                        <<"name">>, <<"TRIM_HORIZON">>, []),
+             Expected = {ok,
+                         [{<<"BatchSize">>,100},
+                          {<<"EventSourceArn">>,<<"arn:aws:kinesis:us-east-1:352283894008:stream/eholland-test">>},
+                          {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                          {<<"LastModified">>,1449845416.123},
+                          {<<"LastProcessingResult">>,<<"No records processed">>},
+                          {<<"State">>,<<"Creating">>},
+                          {<<"StateTransitionReason">>,<<"User action">>},
+                          {<<"UUID">>,<<"3f303f86-7395-43f3-9902-f5c80f0a5382">>}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:create_function(
+                        #erlcloud_lambda_code{s3Bucket = <<"bi-lambda">>,
+                                              s3Key = <<"local_transform/bi-ass"
+                                                        "ets-environment-create"
+                                                        "-environment_1-0-0_lat"
+                                                        "est.zip">>
+                                             },
+                        <<"name">>, <<"index.process">>,
+                        <<"arn:aws:iam::352283894008:role/lambda_basic_execution">>,
+                        nodejs, []),
+             Expected = {ok,[{<<"CodeSha256">>,
+                              <<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                             {<<"CodeSize">>,848},
+                             {<<"Description">>,<<>>},
+                             {<<"FunctionArn">>,
+                              <<"arn:aws:lambda:us-east-1:352283894008:function:name3">>},
+                             {<<"FunctionName">>,<<"name3">>},
+                             {<<"Handler">>,<<"index.process">>},
+                             {<<"LastModified">>,<<"2015-12-11T13:45:31.924+0000">>},
+                             {<<"MemorySize">>,128},
+                             {<<"Role">>,
+                              <<"arn:aws:iam::352283894008:role/lambda_basic_execution">>},
+                             {<<"Runtime">>,<<"nodejs">>},
+                             {<<"Timeout">>,3},
+                             {<<"Version">>,<<"$LATEST">>},
+                             {<<"VpcConfig">>,null}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:delete_event_source_mapping(
+                        <<"6554f300-551b-46a6-829c-41b6af6022c6">>),
+             Expected = {ok,
+                         [{<<"BatchSize">>,100},
+                          {<<"EventSourceArn">>,<<"arn:aws:kinesis:us-east-1:352283894008:stream/eholland-test">>},
+                          {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                          {<<"LastModified">>,1449843960.0},
+                          {<<"LastProcessingResult">>,<<"No records processed">>},
+                          {<<"State">>,<<"Deleting">>},
+                          {<<"StateTransitionReason">>,<<"User action">>},
+                          {<<"UUID">>,<<"a45b58ec-a539-4c47-929e-174b4dd2d963">>}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:get_alias(<<"name">>, <<"aliasName">>),
+             Expected = {ok, [{<<"AliasArn">>,
+                               <<"arn:aws:lambda:us-east-1:352283894008:function:name:aliasName">>},
+                              {<<"Description">>,<<>>},
+                              {<<"FunctionVersion">>,<<"$LATEST">>},
+                              {<<"Name">>,<<"aliasName">>}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:get_event_source_mapping(
+                        <<"a45b58ec-a539-4c47-929e-174b4dd2d963">>),
+             Expected = {ok, [{<<"BatchSize">>,100},
+                              {<<"EventSourceArn">>,
+                               <<"arn:aws:kinesis:us-east-1:352283894008:stream/eholland-test">>},
+                              {<<"FunctionArn">>,
+                               <<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                              {<<"LastModified">>,1449841860.0},
+                              {<<"LastProcessingResult">>,<<"No records processed">>},
+                              {<<"State">>,<<"Enabled">>},
+                              {<<"StateTransitionReason">>,<<"User action">>},
+                              {<<"UUID">>,<<"a45b58ec-a539-4c47-929e-174b4dd2d963">>}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:get_function(<<"name">>),
+             Expected = {ok, [{<<"Code">>,
+                               [{<<"Location">>, <<"https://awslambda-us-east-1-tasks.s3-us-east-1.amazonaws.com/snapshots/352283894008/name-69237aec-bae9-4086-af73-a6610c2f8eb8?x-amz-security-token=AQoDYXdzENb%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEa4APJSJNHsYWnObKlElri5ytVzNg0t%2F0zwADHn40jy%2F1ZDW9%2FYWGi8dTp1l6LWBI9TwJi0LLcgp%2FlCxJIh7hsAPftYX62J9r9lRcmgd9RnYssg1%2Fkpfyjya90epxKg2zdHm%2BuZGukHYDcmAE1IQcHwsaQbvGAjXPCpFyxClbV6gMcFIsaBtfMxoMcbTCXG9m8l56nKgcX6Mi60vRNaB83AeNVrKMhB8EBUUbYbaB%2BG0iJg32i2HBF6VJMxamOLIEf1GJp1tWt%2FSAHfEkdTwcwtGINH3TNRv%2BY3ddsXs8pJ49eY49NCHANPC%2Bq0JzNQydbIK1shz8w1nozXYQo6%2BNh9tqOlaJNFgfFbtJkUDXv4rFqgVsfgJKJSQBeYUKmlNvIPQIoHWhRjjRzQUGmYDc3eEug7vELsNcHZixI4nNVycH%2BJZwaBvswy4eE7gBv3HwHi3SVlg9iXFTrfWTK%2FlCybC7mZIjAmPGiLCG5Pu8SoCgaGdHp8HmSeXXus4VUFcVTUw1qn7E%2BSaRFg3MTpCdu1f1Nqh4pNu7GpZacyLbH%2BSocuPyTjyYGL8sk0C3rjIWZipJcfUZsleS1cXLEGw%2FPAK5eg0RNWlVsaF1WgVimqQh3LtoRZ%2BwYCHRXsHjhCyQ8VhoguJCrswU%3D&AWSAccessKeyId=ASIAIAUY4IMA6JRJ3FSA&Expires=1449843004&Signature=5KUmber1cOBSChlKtnLaI%2FUemU4%3D">>},
+                                {<<"RepositoryType">>,<<"S3">>}]},
+                              {<<"Configuration">>,
+                               [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                                {<<"CodeSize">>,848},
+                                {<<"Description">>,<<>>},
+                                {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                                {<<"FunctionName">>,<<"name">>},
+                                {<<"Handler">>,<<"index.process">>},
+                                {<<"LastModified">>,<<"2015-12-10T13:57:48.214+0000">>},
+                                {<<"MemorySize">>,512},
+                                {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                                {<<"Runtime">>,<<"nodejs">>},
+                                {<<"Timeout">>,30},
+                                {<<"Version">>,<<"$LATEST">>},
+                                {<<"VpcConfig">>,null}]}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:get_function_configuration(<<"name">>),
+             Expected = {ok, [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                              {<<"CodeSize">>,848},
+                              {<<"Description">>,<<>>},
+                              {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                              {<<"FunctionName">>,<<"name">>},
+                              {<<"Handler">>,<<"index.process">>},
+                              {<<"LastModified">>,<<"2015-12-10T13:57:48.214+0000">>},
+                              {<<"MemorySize">>,512},
+                              {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                              {<<"Runtime">>,<<"nodejs">>},
+                              {<<"Timeout">>,30},
+                              {<<"Version">>,<<"$LATEST">>},
+                              {<<"VpcConfig">>,null}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:list_aliases(<<"name">>),
+             Expected = {ok, [{<<"Aliases">>,
+                               [[{<<"AliasArn">>, <<"arn:aws:lambda:us-east-1:352283894008:function:name:aliasName">>},
+                                 {<<"Description">>,<<>>},
+                                 {<<"FunctionVersion">>,<<"$LATEST">>},
+                                 {<<"Name">>,<<"aliasName">>}],
+                                [{<<"AliasArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name:aliasName1">>},
+                                 {<<"Description">>,<<>>},
+                                 {<<"FunctionVersion">>,<<"$LATEST">>},
+                                 {<<"Name">>,<<"aliasName1">>}]]},
+                              {<<"NextMarker">>,null}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:list_event_source_mappings(
+                        <<"arn:aws:kinesis:us-east-1:352283894008:stream/eholland-test">>,
+                        <<"name">>),
+             Expected = {ok, [{<<"EventSourceMappings">>,
+                               [[{<<"BatchSize">>,100},
+                                 {<<"EventSourceArn">>,<<"arn:aws:kinesis:us-east-1:352283894008:stream/eholland-test">>},
+                                 {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                                 {<<"LastModified">>,1449841860.0},
+                                 {<<"LastProcessingResult">>,<<"No records processed">>},
+                                 {<<"State">>,<<"Enabled">>},
+                                 {<<"StateTransitionReason">>,<<"User action">>},
+                                 {<<"UUID">>,<<"a45b58ec-a539-4c47-929e-174b4dd2d963">>}]]},
+                              {<<"NextMarker">>,null}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:list_versions_by_function(<<"name">>),
+             Expected = {ok, [{<<"NextMarker">>,null},
+                              {<<"Versions">>,
+                               [[{<<"CodeSha256">>, <<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                                 {<<"CodeSize">>, 848},
+                                 {<<"Description">>, <<>>},
+                                 {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name:$LATEST">>},
+                                 {<<"FunctionName">>,<<"name">>},
+                                 {<<"Handler">>,<<"index.process">>},
+                                 {<<"LastModified">>,<<"2015-12-10T13:57:48.214+0000">>},
+                                 {<<"MemorySize">>,512},
+                                 {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                                 {<<"Runtime">>,<<"nodejs">>},
+                                 {<<"Timeout">>,30},
+                                 {<<"Version">>,<<"$LATEST">>},
+                                 {<<"VpcConfig">>,null}],
+                                [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                                 {<<"CodeSize">>,848},
+                                 {<<"Description">>,<<>>},
+                                 {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name:1">>},
+                                 {<<"FunctionName">>,<<"name">>},
+                                 {<<"Handler">>,<<"index.process">>},
+                                 {<<"LastModified">>,<<"2015-12-10T11:36:12.776+0000">>},
+                                 {<<"MemorySize">>,128},
+                                 {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                                 {<<"Runtime">>,<<"nodejs">>},
+                                 {<<"Timeout">>,3},
+                                 {<<"Version">>,<<"1">>},
+                                 {<<"VpcConfig">>,null}],
+                                [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                                 {<<"CodeSize">>,848},
+                                 {<<"Description">>,<<>>},
+                                 {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name:2">>},
+                                 {<<"FunctionName">>,<<"name">>},
+                                 {<<"Handler">>,<<"index.process">>},
+                                 {<<"LastModified">>,<<"2015-12-10T13:56:43.171+0000">>},
+                                 {<<"MemorySize">>,128},
+                                 {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                                 {<<"Runtime">>,<<"nodejs">>},
+                                 {<<"Timeout">>,3},
+                                 {<<"Version">>,<<"2">>},
+                                 {<<"VpcConfig">>,null}]]}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:publish_version(<<"name">>),
+             Expected = {ok, [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                              {<<"CodeSize">>,848},
+                              {<<"Description">>,<<>>},
+                              {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name:3">>},
+                              {<<"FunctionName">>,<<"name">>},
+                              {<<"Handler">>,<<"index.process">>},
+                              {<<"LastModified">>,<<"2015-12-10T13:57:48.214+0000">>},
+                              {<<"MemorySize">>,512},
+                              {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                              {<<"Runtime">>,<<"nodejs">>},
+                              {<<"Timeout">>,30},
+                              {<<"Version">>,<<"3">>},
+                              {<<"VpcConfig">>,null}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:update_alias(<<"name">>, <<"aliasName">>),
+             Expected = {ok, [{<<"AliasArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name:aliasName">>},
+                              {<<"Description">>,<<>>},
+                              {<<"FunctionVersion">>,<<"$LATEST">>},
+                              {<<"Name">>,<<"aliasName">>}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:update_event_source_mapping(
+                        <<"a45b58ec-a539-4c47-929e-174b4dd2d963">>,
+                        100, undefined, undefined),
+             Expected = {ok,
+                         [{<<"BatchSize">>,100},
+                          {<<"EventSourceArn">>,<<"arn:aws:kinesis:us-east-1:352283894008:stream/eholland-test">>},
+                          {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                          {<<"LastModified">>,1449844011.991},
+                          {<<"LastProcessingResult">>,<<"No records processed">>},
+                          {<<"State">>,<<"Updating">>},
+                          {<<"StateTransitionReason">>,<<"User action">>},
+                          {<<"UUID">>,<<"a45b58ec-a539-4c47-929e-174b4dd2d963">>}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:update_function_code(
+                        <<"name">>, true, #erlcloud_lambda_code{
+                                             s3Bucket = <<"bi-lambda">>,
+                                             s3Key = <<"local_transform/bi-assets-environment-create-environment_1-0-0_latest.zip">>
+                                            }),
+             Expected = {ok,
+                         [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                          {<<"CodeSize">>,848},
+                          {<<"Description">>,<<>>},
+                          {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name:4">>},
+                          {<<"FunctionName">>,<<"name">>},
+                          {<<"Handler">>,<<"index.process">>},
+                          {<<"LastModified">>,<<"2015-12-11T14:29:17.023+0000">>},
+                          {<<"MemorySize">>,512},
+                          {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                          {<<"Runtime">>,<<"nodejs">>},
+                          {<<"Timeout">>,30},
+                          {<<"Version">>,<<"4">>},
+                          {<<"VpcConfig">>,null}]},
+             ?assertEqual(Expected, Result)
+     end,
+     fun() ->
+             Result = erlcloud_lambda:update_function_configuration(
+                        <<"name">>, undefined, undefined, 512, undefined, 30),
+             Expected = {ok, [{<<"CodeSha256">>,<<"zeoBX1hIWJBHk1muJe1iFyS1CcAmsT0Ct4IcpiPf8QM=">>},
+                              {<<"CodeSize">>,848},
+                              {<<"Description">>,<<>>},
+                              {<<"FunctionArn">>,<<"arn:aws:lambda:us-east-1:352283894008:function:name">>},
+                              {<<"FunctionName">>,<<"name">>},
+                              {<<"Handler">>,<<"index.process">>},
+                              {<<"LastModified">>,<<"2015-12-11T14:31:52.034+0000">>},
+                              {<<"MemorySize">>,512},
+                              {<<"Role">>,<<"arn:aws:iam::352283894008:role/lambda_kinesis_role">>},
+                              {<<"Runtime">>,<<"nodejs">>},
+                              {<<"Timeout">>,30},
+                              {<<"Version">>,<<"$LATEST">>},
+                              {<<"VpcConfig">>,null}]},
+             ?assertEqual(Expected, Result)
+     end
+    ].
+
+make_response(Value) ->
+    {ok, {{200, <<"OK">>}, [], Value}}.


### PR DESCRIPTION
Implements the following API methods as documented http://docs.aws.amazon.com/lambda/latest/dg/API_Operations.html

```
CreateAlias
CreateEventSourceMapping
CreateFunction
DeleteEventSourceMapping
GetAlias
GetEventSourceMapping
GetFunction
GetFunctionConfiguration
ListAliases
ListEventSourceMappings
ListFunctions
ListVersionsByFunction
PublishVersion
UpdateAlias
UpdateEventSourceMapping
UpdateFunctionCode
UpdateFunctionConfiguration
```

@motobob 
