### PR TITLE
Add basic list IAM policies API

### DIFF
--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -7,7 +7,7 @@
 -include_lib("xmerl/include/xmerl.hrl").
 
 %% Library initialization.
--export([configure/2, configure/3, new/2, new/3]).
+-export([configure/2, configure/3, new/2, new/3, iam_query/5]).
 
 %% IAM API Functions
 -export([
@@ -30,6 +30,7 @@
     list_role_policies/1, list_role_policies/2,
     list_attached_role_policies/1, list_attached_role_policies/2, list_attached_role_policies/3,
     get_role_policy/2, get_role_policy/3,
+    list_policies/0, list_policies/1, list_policies/2,list_policies/3,
     get_policy/1, get_policy/2,
     get_policy_version/2, get_policy_version/3,
     list_instance_profiles/0, list_instance_profiles/1, list_instance_profiles/2,
@@ -328,6 +329,26 @@ list_attached_role_policies(RoleName, PathPrefix, #aws_config{} = Config)
 %
 % Policies API
 %
+-spec(list_policies/0 :: () -> proplist()).
+list_policies() ->
+    list_policies("/").
+-spec(list_policies/1 :: (string() | aws_config()) -> proplist()).
+list_policies(#aws_config{} = Config) ->
+    list_policies("/", Config);
+list_policies(PathPrefix) ->
+    list_policies(PathPrefix, default_config()).
+
+-spec(list_policies/2 :: (string(), aws_config()) -> proplist()).
+list_policies(PathPrefix, #aws_config{} = Config) ->
+    list_policies(PathPrefix, false, default_config()).
+
+-spec(list_policies/3 :: (string(), boolean(), aws_config()) -> proplist()).
+list_policies(PathPrefix, OnlyAttached, #aws_config{} = Config)
+        when is_list(PathPrefix), is_boolean(OnlyAttached)->
+    ItemPath = "/ListPoliciesResponse/ListPoliciesResult/Policies/member",
+    iam_query(Config, "ListPolicies", [{"PathPrefix", PathPrefix}, {"OnlyAttached", OnlyAttached}], ItemPath, data_type("Policy")).
+
+
 -spec(get_policy/1 :: (string()) -> proplist()).
 get_policy(PolicyArn) -> get_policy(PolicyArn, default_config()).
 -spec(get_policy/2 :: (string(), aws_config()) -> proplist()).

--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -30,7 +30,7 @@
     list_role_policies/1, list_role_policies/2,
     list_attached_role_policies/1, list_attached_role_policies/2, list_attached_role_policies/3,
     get_role_policy/2, get_role_policy/3,
-    list_policies/0, list_policies/1, list_policies/2,list_policies/3,
+    list_policies/0, list_policies/1, list_policies/2, list_policies/3,
     get_policy/1, get_policy/2,
     get_policy_version/2, get_policy_version/3,
     list_instance_profiles/0, list_instance_profiles/1, list_instance_profiles/2,
@@ -340,13 +340,13 @@ list_policies(PathPrefix) ->
 
 -spec(list_policies/2 :: (string(), aws_config()) -> proplist()).
 list_policies(PathPrefix, #aws_config{} = Config) ->
-    list_policies(PathPrefix, false, default_config()).
+    list_policies(PathPrefix, [], default_config()).
 
--spec(list_policies/3 :: (string(), boolean(), aws_config()) -> proplist()).
-list_policies(PathPrefix, OnlyAttached, #aws_config{} = Config)
-        when is_list(PathPrefix), is_boolean(OnlyAttached)->
+-spec(list_policies/3 :: (string(), list(), aws_config()) -> proplist()).
+list_policies(PathPrefix, ReqParams, #aws_config{} = Config)
+        when is_list(PathPrefix), is_list(ReqParams) ->
     ItemPath = "/ListPoliciesResponse/ListPoliciesResult/Policies/member",
-    iam_query(Config, "ListPolicies", [{"PathPrefix", PathPrefix}, {"OnlyAttached", OnlyAttached}], ItemPath, data_type("Policy")).
+    iam_query(Config, "ListPolicies", [{"PathPrefix", PathPrefix} | ReqParams], ItemPath, data_type("Policy")).
 
 
 -spec(get_policy/1 :: (string()) -> proplist()).

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -1650,8 +1650,7 @@ list_polices_input_tests(_) ->
         ?_f(erlcloud_iam:list_policies("test")),
         [
           {"Action", "ListPolicies"},
-          {"PathPrefix", "test"},
-          {"OnlyAttached", "false"}
+          {"PathPrefix", "test"}
         ]})
     ],
 

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -73,6 +73,8 @@ iam_api_test_() ->
       fun list_attached_group_policies_output_tests/1,
       fun list_attached_role_policies_input_tests/1,
       fun list_attached_role_policies_output_tests/1,
+      fun list_polices_input_tests/1,
+      fun list_polices_output_tests/1,
       fun get_policy_input_tests/1,
       fun get_policy_output_tests/1,
       fun get_policy_version_input_tests/1,
@@ -1638,6 +1640,68 @@ list_attached_role_policies_output_tests(_) ->
             <RequestId>684f0917-3d22-11e4-a4a0-cffb9EXAMPLE</RequestId>
           </ResponseMetadata>
         </GetPolicyResponse>").
+
+%% ListUsers test based on the API examples:
+%% http://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicies.html
+list_polices_input_tests(_) ->
+  Tests =
+    [?_iam_test(
+      {"Test returning all polices in an account.",
+        ?_f(erlcloud_iam:list_policies("test")),
+        [
+          {"Action", "ListPolicies"},
+          {"PathPrefix", "test"},
+          {"OnlyAttached", "false"}
+        ]})
+    ],
+
+  Response = "
+      <ListPoliciesResponse>
+         <ResponseMetadata>
+            <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+         </ResponseMetadata>
+      </ListPoliciesResponse>",
+  input_tests(Response, Tests).
+
+list_polices_output_tests(_) ->
+  Tests = [?_iam_test(
+    {"This lists all policies in your account",
+        "<ListPoliciesResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\">
+          <ListPoliciesResult>
+            <IsTruncated>true</IsTruncated>
+            <Marker>EXAMPLEkakv9BCuUNFDtxWSyfzetYwEx2ADc8dnzfvERF5S6YMvXKx41t6gCl/eeaCX3Jo94/bKqezEAg8TEVS
+            99EKFLxm3jtbpl25FDWEXAMPLE
+            </Marker>
+            <Policies>
+              <member>
+                <PolicyName>ExamplePolicy</PolicyName>
+                <DefaultVersionId>v1</DefaultVersionId>
+                <PolicyId>AGPACKCEVSQ6C2EXAMPLE</PolicyId>
+                <Path>/</Path>
+                <Arn>arn:aws:iam::123456789012:policy/ExamplePolicy</Arn>
+                <AttachmentCount>2</AttachmentCount>
+                <CreateDate>2014-09-15T17:36:14Z</CreateDate>
+                <UpdateDate>2014-09-15T20:31:47Z</UpdateDate>
+              </member>
+            </Policies>
+          </ListPoliciesResult>
+          <ResponseMetadata>
+            <RequestId>6207e832-3eb7-11e4-9d0d-6f969EXAMPLE</RequestId>
+          </ResponseMetadata>
+        </ListPoliciesResponse>",
+      {ok, [[{update_date, {{2014,9,15},{20,31,47}}},
+          {create_date, {{2014,9,15},{17,36,14}}},
+          {attachment_count, 2},
+          {arn, "arn:aws:iam::123456789012:policy/ExamplePolicy"},
+          {path, "/"},
+          {policy_id, "AGPACKCEVSQ6C2EXAMPLE"},
+          {default_version_id, "v1"},
+          {policy_name, "ExamplePolicy"}
+      ]]}
+    })
+  ],
+  output_tests(?_f(erlcloud_iam:list_policies("test")), Tests).
+
 get_policy_input_tests(_) ->
     Tests =
         [?_iam_test(


### PR DESCRIPTION
Add basic list policies api.

Marker support omitted for now as in the whole `iam` module

@kkuzmin @alexturkin 
