### PR TITLE
IAM pagination support implemented

### DIFF
--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -14,27 +14,41 @@
     %% Users
     get_user/0, get_user/1, get_user/2, 
     list_access_keys/0, list_access_keys/1, list_access_keys/2,
+    list_access_keys_all/0, list_access_keys_all/1, list_access_keys_all/2,
     list_users/0, list_users/1, list_users/2,
+    list_users_all/0, list_users_all/1, list_users_all/2,
     list_groups_for_user/1, list_groups_for_user/2,
+    list_groups_for_user_all/1, list_groups_for_user_all/2,
     list_user_policies/1, list_user_policies/2,
+    list_user_policies_all/1, list_user_policies_all/2,
     list_attached_user_policies/1, list_attached_user_policies/2, list_attached_user_policies/3,
+    list_attached_user_policies_all/1, list_attached_user_policies_all/2, list_attached_user_policies_all/3,
     get_user_policy/2, get_user_policy/3,
     get_login_profile/1, get_login_profile/2,
     get_group/1, get_group/2, 
     list_groups/0, list_groups/1, list_groups/2,
+    list_groups_all/0, list_groups_all/1, list_groups_all/2,
     list_group_policies/1, list_group_policies/2,
+    list_group_policies_all/1, list_group_policies_all/2,
     get_group_policy/2, get_group_policy/3,
     list_attached_group_policies/1, list_attached_group_policies/2, list_attached_group_policies/3,
+    list_attached_group_policies_all/1, list_attached_group_policies_all/2, list_attached_group_policies_all/3,
     get_role/1, get_role/2, 
     list_roles/0, list_roles/1, list_roles/2,
+    list_roles_all/0, list_roles_all/1, list_roles_all/2,
     list_role_policies/1, list_role_policies/2,
+    list_role_policies_all/1, list_role_policies_all/2,
     list_attached_role_policies/1, list_attached_role_policies/2, list_attached_role_policies/3,
+    list_attached_role_policies_all/1, list_attached_role_policies_all/2, list_attached_role_policies_all/3,
     get_role_policy/2, get_role_policy/3,
     list_policies/0, list_policies/1, list_policies/2, list_policies/3,
+    list_policies_all/0, list_policies_all/1, list_policies_all/2, list_policies_all/3,
     list_entities_for_policy/1, list_entities_for_policy/2, list_entities_for_policy/3, list_entities_for_policy/4,
+    list_entities_for_policy_all/1, list_entities_for_policy_all/2, list_entities_for_policy_all/3, list_entities_for_policy_all/4,
     get_policy/1, get_policy/2,
     get_policy_version/2, get_policy_version/3,
     list_instance_profiles/0, list_instance_profiles/1, list_instance_profiles/2,
+    list_instance_profiles_all/0, list_instance_profiles_all/1, list_instance_profiles_all/2,
     get_instance_profile/1, get_instance_profile/2,
     get_account_authorization_details/0, get_account_authorization_details/1,
     get_account_summary/0, get_account_summary/1,
@@ -74,15 +88,15 @@ configure(AccessKeyID, SecretAccessKey, Host) ->
 %
 % Users API
 %
--spec(get_user/0 :: () -> proplist()).
+-spec(get_user/0 :: () -> {ok, proplist()} |  {error, any()}).
 get_user() -> get_user([]).
--spec(get_user/1 :: (string() | aws_config()) -> proplist()).
+-spec(get_user/1 :: (string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_user(#aws_config{} = Config) ->
     get_user("", Config);
 get_user(UserName) ->
     get_user(UserName, default_config()).
 
--spec(get_user/2 :: (string(), aws_config()) -> proplist()).
+-spec(get_user/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_user("", Config) ->
     get_user_impl([], Config);
 get_user(UserName, Config) ->
@@ -95,17 +109,17 @@ get_user_impl(UserNameParam, #aws_config{} = Config) ->
         {error, _} = Error -> Error
     end.
 
--spec(list_access_keys/0 :: () -> proplist()).
+-spec(list_access_keys/0 :: () -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_access_keys() ->
     list_access_keys([]).
 
--spec(list_access_keys/1 :: (string() | aws_config()) -> proplist()).
+-spec(list_access_keys/1 :: (string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_access_keys(#aws_config{} = Config) ->
     list_access_keys([], Config);
 list_access_keys(UserName) ->
     list_access_keys(UserName, default_config()).
 
--spec(list_access_keys/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_access_keys/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_access_keys(UserName, #aws_config{} = Config) when is_list(UserName) ->
     Params = case UserName of
                  [] -> [];
@@ -114,62 +128,113 @@ list_access_keys(UserName, #aws_config{} = Config) when is_list(UserName) ->
     ItemPath = "/ListAccessKeysResponse/ListAccessKeysResult/AccessKeyMetadata/member",
     iam_query(Config, "ListAccessKeys", Params, ItemPath, data_type("AccessKeyMetadata")).
 
-% TODO: Make sure to handle pagination of results
--spec(list_users/0 :: () -> proplist()).
+-spec(list_access_keys_all/0 :: () -> {ok, proplist()} |  {error, any()}).
+list_access_keys_all() ->
+    list_access_keys_all([]).
+
+-spec(list_access_keys_all/1 :: (string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_access_keys_all(#aws_config{} = Config) ->
+    list_access_keys_all([], Config);
+list_access_keys_all(UserName) ->
+    list_access_keys_all(UserName, default_config()).
+
+-spec(list_access_keys_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_access_keys_all(UserName, #aws_config{} = Config) when is_list(UserName) ->
+    Params = case UserName of
+                 [] -> [];
+                 UserName -> [{"UserName", UserName}]
+             end,
+    ItemPath = "/ListAccessKeysResponse/ListAccessKeysResult/AccessKeyMetadata/member",
+    iam_query_all(Config, "ListAccessKeys", Params, ItemPath, data_type("AccessKeyMetadata")).
+
+-spec(list_users/0 :: () -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_users() -> list_users("/").
--spec(list_users/1 :: (string() | aws_config()) -> proplist()).
+-spec(list_users/1 :: (string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_users(#aws_config{} = Config) ->
     list_users("/", Config);
 list_users(PathPrefix) ->
     list_users(PathPrefix, default_config()).
 
--spec(list_users/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_users/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_users(PathPrefix, #aws_config{} = Config)
   when is_list(PathPrefix) ->
     ItemPath = "/ListUsersResponse/ListUsersResult/Users/member",
     iam_query(Config, "ListUsers", [{"PathPrefix", PathPrefix}], ItemPath, data_type("User")).
 
--spec(list_groups_for_user/1 :: (string()) -> proplist()).
+-spec(list_users_all/0 :: () -> {ok, proplist()} |  {error, any()}).
+list_users_all() -> list_users_all("/").
+-spec(list_users_all/1 :: (string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_users_all(#aws_config{} = Config) ->
+    list_users_all("/", Config);
+list_users_all(PathPrefix) ->
+    list_users_all(PathPrefix, default_config()).
+
+-spec(list_users_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_users_all(PathPrefix, #aws_config{} = Config)
+  when is_list(PathPrefix) ->
+    ItemPath = "/ListUsersResponse/ListUsersResult/Users/member",
+    iam_query_all(Config, "ListUsers", [{"PathPrefix", PathPrefix}], ItemPath, data_type("User")).
+
+-spec(list_groups_for_user/1 :: (string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_groups_for_user(UserName) ->
     list_groups_for_user(UserName, default_config()).
 
--spec(list_groups_for_user/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_groups_for_user/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_groups_for_user(UserName, #aws_config{} = Config) ->
     ItemPath = "/ListGroupsForUserResponse/ListGroupsForUserResult/Groups/member",
     iam_query(Config, "ListGroupsForUser", [{"UserName", UserName}], ItemPath, data_type("Group")).
 
--spec(list_user_policies/1 :: (string()) -> proplist()).
+-spec(list_groups_for_user_all/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
+list_groups_for_user_all(UserName) ->
+    list_groups_for_user_all(UserName, default_config()).
+
+-spec(list_groups_for_user_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_groups_for_user_all(UserName, #aws_config{} = Config) ->
+    ItemPath = "/ListGroupsForUserResponse/ListGroupsForUserResult/Groups/member",
+    iam_query_all(Config, "ListGroupsForUser", [{"UserName", UserName}], ItemPath, data_type("Group")).
+
+-spec(list_user_policies/1 :: (string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_user_policies(UserName) ->
     list_user_policies(UserName, default_config()).
 
--spec(list_user_policies/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_user_policies/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_user_policies(UserName, #aws_config{} = Config) ->
     ItemPath = "/ListUserPoliciesResponse/ListUserPoliciesResult/PolicyNames/member",
     DataType = [{policy_name, "String"}],
     iam_query(Config, "ListUserPolicies", [{"UserName", UserName}], ItemPath, DataType).
 
--spec(get_user_policy/2 :: (string(), string()) -> proplist()).
+-spec(list_user_policies_all/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
+list_user_policies_all(UserName) ->
+    list_user_policies_all(UserName, default_config()).
+
+-spec(list_user_policies_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_user_policies_all(UserName, #aws_config{} = Config) ->
+    ItemPath = "/ListUserPoliciesResponse/ListUserPoliciesResult/PolicyNames/member",
+    DataType = [{policy_name, "String"}],
+    iam_query_all(Config, "ListUserPolicies", [{"UserName", UserName}], ItemPath, DataType).
+
+-spec(get_user_policy/2 :: (string(), string()) -> {ok, proplist()} |  {error, any()}).
 get_user_policy(UserName, PolicyName) ->
     get_user_policy(UserName, PolicyName, default_config()).
 
--spec(get_user_policy/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec(get_user_policy/3 :: (string(), string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_user_policy(UserName, PolicyName, #aws_config{} = Config) ->
     ItemPath = "/GetUserPolicyResponse/GetUserPolicyResult",
     Params = [{"UserName", UserName}, {"PolicyName", PolicyName}],
     iam_query(Config, "GetUserPolicy", Params, ItemPath, data_type("UserPolicyList")).
 
--spec(list_attached_user_policies/1 :: (string()) -> proplist()).
+-spec(list_attached_user_policies/1 :: (string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_user_policies(UserName) ->
     list_attached_user_policies(UserName, "/", default_config()).
 
--spec(list_attached_user_policies/2 :: (string(), string() | aws_config()) -> proplist()).
+-spec(list_attached_user_policies/2 :: (string(), string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_user_policies(UserName, #aws_config{} = Config) ->
     list_attached_user_policies(UserName, "/", Config);
 list_attached_user_policies(UserName, PathPrefix)
   when is_list(UserName), is_list(PathPrefix) ->
     list_attached_user_policies(UserName, PathPrefix, default_config()).
 
--spec(list_attached_user_policies/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec(list_attached_user_policies/3 :: (string(), string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_user_policies(UserName, [], Config) ->
     list_attached_user_policies(UserName, "/", Config);
 list_attached_user_policies(UserName, PathPrefix, #aws_config{} = Config)
@@ -178,11 +243,31 @@ list_attached_user_policies(UserName, PathPrefix, #aws_config{} = Config)
     Params = [{"UserName", UserName}, {"PathPrefix", PathPrefix}],
     iam_query(Config, "ListAttachedUserPolicies", Params, ItemPath, data_type("AttachedPolicy")).
 
--spec(get_login_profile/1 :: (string()) -> proplist()).
+-spec(list_attached_user_policies_all/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
+list_attached_user_policies_all(UserName) ->
+    list_attached_user_policies_all(UserName, "/", default_config()).
+
+-spec(list_attached_user_policies_all/2 :: (string(), string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_attached_user_policies_all(UserName, #aws_config{} = Config) ->
+    list_attached_user_policies_all(UserName, "/", Config);
+list_attached_user_policies_all(UserName, PathPrefix)
+  when is_list(UserName), is_list(PathPrefix) ->
+    list_attached_user_policies_all(UserName, PathPrefix, default_config()).
+
+-spec(list_attached_user_policies_all/3 :: (string(), string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_attached_user_policies_all(UserName, [], Config) ->
+    list_attached_user_policies_all(UserName, "/", Config);
+list_attached_user_policies_all(UserName, PathPrefix, #aws_config{} = Config)
+  when is_list(UserName), is_list(PathPrefix) ->
+    ItemPath = "/ListAttachedUserPoliciesResponse/ListAttachedUserPoliciesResult/AttachedPolicies/member",
+    Params = [{"UserName", UserName}, {"PathPrefix", PathPrefix}],
+    iam_query_all(Config, "ListAttachedUserPolicies", Params, ItemPath, data_type("AttachedPolicy")).
+
+-spec(get_login_profile/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
 get_login_profile(UserName) ->
     get_login_profile(UserName, default_config()).
 
--spec(get_login_profile/2 :: (string(), aws_config()) -> proplist()).
+-spec(get_login_profile/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_login_profile(UserName, #aws_config{} = Config) ->
     ItemPath = "/GetLoginProfileResponse/GetLoginProfileResult/LoginProfile",
     iam_query(Config, "GetLoginProfile", [{"UserName", UserName}], ItemPath, data_type("LoginProfile")).
@@ -190,11 +275,11 @@ get_login_profile(UserName, #aws_config{} = Config) ->
 %
 % Groups API
 %
--spec(get_group/1 :: (string()) -> proplist()).
+-spec(get_group/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
 get_group(GroupName) when is_list(GroupName)->
     get_group(GroupName, default_config()).
 
--spec(get_group/2 :: (string(), aws_config()) -> proplist()).
+-spec(get_group/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_group(GroupName, Config) ->
     get_group_impl([{"GroupName", GroupName}], Config).
     
@@ -205,66 +290,108 @@ get_group_impl(GroupNameParam, #aws_config{} = Config) ->
         {error, _} = Error -> Error
     end.
 
--spec(list_groups/0 :: () -> proplist()).
+-spec(list_groups/0 :: () -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_groups() -> list_groups([]).
--spec(list_groups/1 :: (string() | aws_config()) -> proplist()).
+-spec(list_groups/1 :: (string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_groups(#aws_config{} = Config) ->
     list_groups("/", Config);
 list_groups(PathPrefix) ->
     list_groups(PathPrefix, default_config()).
 
--spec(list_groups/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_groups/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_groups(PathPrefix, Config)
   when is_list(PathPrefix) ->
     ItemPath = "/ListGroupsResponse/ListGroupsResult/Groups/member",
     iam_query(Config, "ListGroups", [{"PathPrefix", PathPrefix}], ItemPath, data_type("Group")).
 
--spec(list_group_policies/1 :: (string()) -> proplist()).
+-spec(list_groups_all/0 :: () -> {ok, proplist()} |  {error, any()}).
+list_groups_all() -> list_groups_all([]).
+-spec(list_groups_all/1 :: (string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_groups_all(#aws_config{} = Config) ->
+    list_groups_all("/", Config);
+list_groups_all(PathPrefix) ->
+    list_groups_all(PathPrefix, default_config()).
+
+-spec(list_groups_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_groups_all(PathPrefix, Config)
+  when is_list(PathPrefix) ->
+    ItemPath = "/ListGroupsResponse/ListGroupsResult/Groups/member",
+    iam_query_all(Config, "ListGroups", [{"PathPrefix", PathPrefix}], ItemPath, data_type("Group")).
+
+-spec(list_group_policies/1 :: (string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_group_policies(GroupName) ->
     list_group_policies(GroupName, default_config()).
 
--spec(list_group_policies/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_group_policies/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_group_policies(GroupName, #aws_config{} = Config) ->
     ItemPath = "/ListGroupPoliciesResponse/ListGroupPoliciesResult/PolicyNames/member",
     DataTypeDef = [{policy_name, "String"}],
     iam_query(Config, "ListGroupPolicies", [{"GroupName", GroupName}], ItemPath, DataTypeDef).
 
--spec(get_group_policy/2 :: (string(), string()) -> proplist()).
+-spec(list_group_policies_all/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
+list_group_policies_all(GroupName) ->
+    list_group_policies_all(GroupName, default_config()).
+
+-spec(list_group_policies_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_group_policies_all(GroupName, #aws_config{} = Config) ->
+    ItemPath = "/ListGroupPoliciesResponse/ListGroupPoliciesResult/PolicyNames/member",
+    DataTypeDef = [{policy_name, "String"}],
+    iam_query_all(Config, "ListGroupPolicies", [{"GroupName", GroupName}], ItemPath, DataTypeDef).
+
+-spec(get_group_policy/2 :: (string(), string()) -> {ok, proplist()} |  {error, any()}).
 get_group_policy(GroupName, PolicyName) ->
     get_group_policy(GroupName, PolicyName, default_config()).
 
--spec(get_group_policy/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec(get_group_policy/3 :: (string(), string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_group_policy(GroupName, PolicyName, #aws_config{} = Config) ->
     ItemPath = "/GetGroupPolicyResponse/GetGroupPolicyResult",
     Params = [{"GroupName", GroupName}, {"PolicyName", PolicyName}],
     iam_query(Config, "GetGroupPolicy", Params, ItemPath, data_type("GroupPolicyList")).
 
--spec(list_attached_group_policies/1 :: (string()) -> proplist()).
+-spec(list_attached_group_policies/1 :: (string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_group_policies(GroupName) ->
     list_attached_group_policies(GroupName, "/", default_config()).
 
--spec(list_attached_group_policies/2 :: (string(), string() | aws_config()) -> proplist()).
+-spec(list_attached_group_policies/2 :: (string(), string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_group_policies(GroupName, #aws_config{} = Config) ->
     list_attached_group_policies(GroupName, "/", Config);
 list_attached_group_policies(GroupName, PathPrefix)
   when is_list(GroupName), is_list(PathPrefix) ->
     list_attached_group_policies(GroupName, PathPrefix, default_config()).
 
--spec(list_attached_group_policies/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec(list_attached_group_policies/3 :: (string(), string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_group_policies(GroupName, PathPrefix, #aws_config{} = Config)
   when is_list(GroupName), is_list(PathPrefix) ->
     ItemPath = "/ListAttachedGroupPoliciesResponse/ListAttachedGroupPoliciesResult/AttachedPolicies/member",
     Params = [{"GroupName", GroupName}, {"PathPrefix", PathPrefix}],
     iam_query(Config, "ListAttachedGroupPolicies", Params, ItemPath, data_type("AttachedPolicy")).
 
+-spec(list_attached_group_policies_all/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
+list_attached_group_policies_all(GroupName) ->
+    list_attached_group_policies_all(GroupName, "/", default_config()).
+
+-spec(list_attached_group_policies_all/2 :: (string(), string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_attached_group_policies_all(GroupName, #aws_config{} = Config) ->
+    list_attached_group_policies_all(GroupName, "/", Config);
+list_attached_group_policies_all(GroupName, PathPrefix)
+  when is_list(GroupName), is_list(PathPrefix) ->
+    list_attached_group_policies_all(GroupName, PathPrefix, default_config()).
+
+-spec(list_attached_group_policies_all/3 :: (string(), string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_attached_group_policies_all(GroupName, PathPrefix, #aws_config{} = Config)
+  when is_list(GroupName), is_list(PathPrefix) ->
+    ItemPath = "/ListAttachedGroupPoliciesResponse/ListAttachedGroupPoliciesResult/AttachedPolicies/member",
+    Params = [{"GroupName", GroupName}, {"PathPrefix", PathPrefix}],
+    iam_query_all(Config, "ListAttachedGroupPolicies", Params, ItemPath, data_type("AttachedPolicy")).
+
 %
 % Roles API
 %
--spec(get_role/1 :: (string()) -> proplist()).
+-spec(get_role/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
 get_role(RoleName) when is_list(RoleName) ->
     get_role(RoleName, default_config()).
 
--spec(get_role/2 :: (string(), aws_config()) -> proplist()).
+-spec(get_role/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_role(RoleName, Config) ->
     get_role_impl([{"RoleName", RoleName}], Config).
     
@@ -275,111 +402,191 @@ get_role_impl(RoleNameParam, #aws_config{} = Config) ->
         {error, _} = Error -> Error
     end.
 
--spec(list_roles/0 :: () -> proplist()).
+-spec(list_roles/0 :: () -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_roles() -> list_roles([]).
--spec(list_roles/1 :: (string() | aws_config()) -> proplist()).
+-spec(list_roles/1 :: (string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_roles(#aws_config{} = Config) ->
     list_roles("/", Config);
 list_roles(PathPrefix) ->
     list_roles(PathPrefix, default_config()).
 
--spec(list_roles/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_roles/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_roles(PathPrefix, #aws_config{} = Config)
   when is_list(PathPrefix) ->
     ItemPath = "/ListRolesResponse/ListRolesResult/Roles/member",
     iam_query(Config, "ListRoles", [{"PathPrefix", PathPrefix}], ItemPath, data_type("Role")).
 
--spec(list_role_policies/1 :: (string()) -> proplist()).
+-spec(list_roles_all/0 :: () -> {ok, proplist()} |  {error, any()}).
+list_roles_all() -> list_roles([]).
+-spec(list_roles_all/1 :: (string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_roles_all(#aws_config{} = Config) ->
+    list_roles_all("/", Config);
+list_roles_all(PathPrefix) ->
+    list_roles_all(PathPrefix, default_config()).
+
+-spec(list_roles_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_roles_all(PathPrefix, #aws_config{} = Config)
+  when is_list(PathPrefix) ->
+    ItemPath = "/ListRolesResponse/ListRolesResult/Roles/member",
+    iam_query_all(Config, "ListRoles", [{"PathPrefix", PathPrefix}], ItemPath, data_type("Role")).
+
+-spec(list_role_policies/1 :: (string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_role_policies(RoleName) ->
     list_role_policies(RoleName, default_config()).
 
--spec(list_role_policies/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_role_policies/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_role_policies(RoleName, #aws_config{} = Config) ->
     ItemPath = "/ListRolePoliciesResponse/ListRolePoliciesResult/PolicyNames/member",
     DataTypeDef = [{policy_name, "String"}],
     iam_query(Config, "ListRolePolicies", [{"RoleName", RoleName}], ItemPath, DataTypeDef).
 
--spec(get_role_policy/2 :: (string(), string()) -> proplist()).
+-spec(list_role_policies_all/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
+list_role_policies_all(RoleName) ->
+    list_role_policies_all(RoleName, default_config()).
+
+-spec(list_role_policies_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_role_policies_all(RoleName, #aws_config{} = Config) ->
+    ItemPath = "/ListRolePoliciesResponse/ListRolePoliciesResult/PolicyNames/member",
+    DataTypeDef = [{policy_name, "String"}],
+    iam_query_all(Config, "ListRolePolicies", [{"RoleName", RoleName}], ItemPath, DataTypeDef).
+
+-spec(get_role_policy/2 :: (string(), string()) -> {ok, proplist()} |  {error, any()}).
 get_role_policy(RoleName, PolicyName) ->
     get_role_policy(RoleName, PolicyName, default_config()).
 
--spec(get_role_policy/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec(get_role_policy/3 :: (string(), string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_role_policy(RoleName, PolicyName, #aws_config{} = Config) ->
     ItemPath = "/GetRolePolicyResponse/GetRolePolicyResult",
     Params = [{"RoleName", RoleName}, {"PolicyName", PolicyName}],
     iam_query(Config, "GetRolePolicy", Params, ItemPath, data_type("RolePolicyList")).
 
--spec(list_attached_role_policies/1 :: (string()) -> proplist()).
+-spec(list_attached_role_policies/1 :: (string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_role_policies(RoleName) ->
     list_attached_role_policies(RoleName, "/", default_config()).
 
--spec(list_attached_role_policies/2 :: (string(), string() | aws_config()) -> proplist()).
+-spec(list_attached_role_policies/2 :: (string(), string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_role_policies(RoleName, #aws_config{} = Config) ->
     list_attached_role_policies(RoleName, "/", Config);
 list_attached_role_policies(RoleName, PathPrefix)
   when is_list(RoleName), is_list(PathPrefix) ->
     list_attached_role_policies(RoleName, PathPrefix, default_config()).
 
--spec(list_attached_role_policies/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec(list_attached_role_policies/3 :: (string(), string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_attached_role_policies(RoleName, PathPrefix, #aws_config{} = Config)
   when is_list(RoleName), is_list(PathPrefix) ->
     ItemPath = "/ListAttachedRolePoliciesResponse/ListAttachedRolePoliciesResult/AttachedPolicies/member",
     Params = [{"RoleName", RoleName}, {"PathPrefix", PathPrefix}],
     iam_query(Config, "ListAttachedRolePolicies", Params, ItemPath, data_type("AttachedPolicy")).
 
+-spec(list_attached_role_policies_all/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
+list_attached_role_policies_all(RoleName) ->
+    list_attached_role_policies_all(RoleName, "/", default_config()).
+
+-spec(list_attached_role_policies_all/2 :: (string(), string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_attached_role_policies_all(RoleName, #aws_config{} = Config) ->
+    list_attached_role_policies_all(RoleName, "/", Config);
+list_attached_role_policies_all(RoleName, PathPrefix)
+  when is_list(RoleName), is_list(PathPrefix) ->
+    list_attached_role_policies_all(RoleName, PathPrefix, default_config()).
+
+-spec(list_attached_role_policies_all/3 :: (string(), string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_attached_role_policies_all(RoleName, PathPrefix, #aws_config{} = Config)
+  when is_list(RoleName), is_list(PathPrefix) ->
+    ItemPath = "/ListAttachedRolePoliciesResponse/ListAttachedRolePoliciesResult/AttachedPolicies/member",
+    Params = [{"RoleName", RoleName}, {"PathPrefix", PathPrefix}],
+    iam_query_all(Config, "ListAttachedRolePolicies", Params, ItemPath, data_type("AttachedPolicy")).
+
 %
 % Policies API
 %
--spec(list_policies/0 :: () -> proplist()).
+-spec(list_policies/0 :: () -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_policies() ->
     list_policies("/").
--spec(list_policies/1 :: (string() | aws_config()) -> proplist()).
+-spec(list_policies/1 :: (string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_policies(#aws_config{} = Config) ->
     list_policies("/", Config);
 list_policies(PathPrefix) ->
     list_policies(PathPrefix, default_config()).
 
--spec(list_policies/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_policies/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_policies(PathPrefix, #aws_config{} = Config) ->
     list_policies(PathPrefix, [], Config).
 
--spec(list_policies/3 :: (string(), list(), aws_config()) -> proplist()).
+-spec(list_policies/3 :: (string(), list(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_policies(PathPrefix, ReqParams, #aws_config{} = Config)
         when is_list(PathPrefix), is_list(ReqParams) ->
     ItemPath = "/ListPoliciesResponse/ListPoliciesResult/Policies/member",
     iam_query(Config, "ListPolicies", [{"PathPrefix", PathPrefix} | ReqParams], ItemPath, data_type("Policy")).
 
--spec(list_entities_for_policy/1 :: (string()) -> proplist()).
+-spec(list_policies_all/0 :: () -> {ok, proplist()} |  {error, any()}).
+list_policies_all() ->
+    list_policies_all("/").
+-spec(list_policies_all/1 :: (string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_policies_all(#aws_config{} = Config) ->
+    list_policies_all("/", Config);
+list_policies_all(PathPrefix) ->
+    list_policies_all(PathPrefix, default_config()).
+
+-spec(list_policies_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_policies_all(PathPrefix, #aws_config{} = Config) ->
+    list_policies_all(PathPrefix, [], Config).
+
+-spec(list_policies_all/3 :: (string(), list(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_policies_all(PathPrefix, ReqParams, #aws_config{} = Config)
+        when is_list(PathPrefix), is_list(ReqParams) ->
+    ItemPath = "/ListPoliciesResponse/ListPoliciesResult/Policies/member",
+    iam_query_all(Config, "ListPolicies", [{"PathPrefix", PathPrefix} | ReqParams], ItemPath, data_type("Policy")).
+
+-spec(list_entities_for_policy/1 :: (string()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_entities_for_policy(PolicyArn) ->
   list_entities_for_policy(PolicyArn, default_config()).
 
--spec(list_entities_for_policy/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_entities_for_policy/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_entities_for_policy(PolicyArn, #aws_config{} = Config) ->
   list_entities_for_policy(PolicyArn, "/", Config).
 
--spec(list_entities_for_policy/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec(list_entities_for_policy/3 :: (string(), string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_entities_for_policy(PolicyArn, PathPrefix, #aws_config{} = Config) ->
   list_entities_for_policy(PolicyArn, PathPrefix, [], Config).
 
--spec(list_entities_for_policy/4 :: (string(), string(), list(), aws_config()) -> proplist()).
+-spec(list_entities_for_policy/4 :: (string(), string(), list(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_entities_for_policy(PolicyArn, PathPrefix, ReqParams, #aws_config{} = Config)
         when is_list(PathPrefix), is_list(PolicyArn), is_list(ReqParams) ->
     ItemPath = "/ListEntitiesForPolicyResponse/ListEntitiesForPolicyResult",
     Params = [{"PathPrefix", PathPrefix} , {"PolicyArn", PolicyArn} | ReqParams],
     iam_query(Config, "ListEntitiesForPolicy", Params, ItemPath, data_type("EntitiesPolicyList")).
 
--spec(get_policy/1 :: (string()) -> proplist()).
+-spec(list_entities_for_policy_all/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
+list_entities_for_policy_all(PolicyArn) ->
+  list_entities_for_policy_all(PolicyArn, default_config()).
+
+-spec(list_entities_for_policy_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_entities_for_policy_all(PolicyArn, #aws_config{} = Config) ->
+  list_entities_for_policy_all(PolicyArn, "/", Config).
+
+-spec(list_entities_for_policy_all/3 :: (string(), string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_entities_for_policy_all(PolicyArn, PathPrefix, #aws_config{} = Config) ->
+  list_entities_for_policy_all(PolicyArn, PathPrefix, [], Config).
+
+-spec(list_entities_for_policy_all/4 :: (string(), string(), list(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_entities_for_policy_all(PolicyArn, PathPrefix, ReqParams, #aws_config{} = Config)
+        when is_list(PathPrefix), is_list(PolicyArn), is_list(ReqParams) ->
+    ItemPath = "/ListEntitiesForPolicyResponse/ListEntitiesForPolicyResult",
+    Params = [{"PathPrefix", PathPrefix} , {"PolicyArn", PolicyArn} | ReqParams],
+    iam_query_all(Config, "ListEntitiesForPolicy", Params, ItemPath, data_type("EntitiesPolicyList")).
+
+-spec(get_policy/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
 get_policy(PolicyArn) -> get_policy(PolicyArn, default_config()).
--spec(get_policy/2 :: (string(), aws_config()) -> proplist()).
+-spec(get_policy/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_policy(PolicyArn, #aws_config{} = Config)
   when is_list(PolicyArn) ->
     ItemPath = "/GetPolicyResponse/GetPolicyResult/Policy",
     iam_query(Config, "GetPolicy", [{"PolicyArn", PolicyArn}], ItemPath, data_type("Policy")).
 
--spec(get_policy_version/2 :: (string(), string()) -> proplist()).
+-spec(get_policy_version/2 :: (string(), string()) -> {ok, proplist()} |  {error, any()}).
 get_policy_version(PolicyArn, VersionId) ->
     get_policy_version(PolicyArn, VersionId, default_config()).
--spec(get_policy_version/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec(get_policy_version/3 :: (string(), string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_policy_version(PolicyArn, VersionId, #aws_config{} = Config)
   when is_list(PolicyArn), is_list(VersionId) ->
     ItemPath = "/GetPolicyVersionResponse/GetPolicyVersionResult/PolicyVersion",
@@ -388,28 +595,45 @@ get_policy_version(PolicyArn, VersionId, #aws_config{} = Config)
 %
 % InstanceProfile
 %
--spec(list_instance_profiles/0 :: () -> proplist()).
+-spec(list_instance_profiles/0 :: () -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_instance_profiles() ->
     list_instance_profiles(default_config()).
 
--spec(list_instance_profiles/1 :: (string() | aws_config()) -> proplist()).
+-spec(list_instance_profiles/1 :: (string() | aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_instance_profiles(#aws_config{} = Config) ->
     list_instance_profiles("/", Config);
 
 list_instance_profiles(PathPrefix) ->
     list_instance_profiles(PathPrefix, default_config()).
 
--spec(list_instance_profiles/2 :: (string(), aws_config()) -> proplist()).
+-spec(list_instance_profiles/2 :: (string(), aws_config()) -> {ok, proplist()} | {ok, proplist(), string()} |  {error, any()}).
 list_instance_profiles(PathPrefix, #aws_config{} = Config) ->
     ItemPath = "/ListInstanceProfilesResponse/ListInstanceProfilesResult/InstanceProfiles/member",
     Params = [{"PathPrefix", PathPrefix}],
     iam_query(Config, "ListInstanceProfiles", Params, ItemPath, data_type("InstanceProfile")).
 
--spec(get_instance_profile/1 :: (string()) -> proplist()).
+-spec(list_instance_profiles_all/0 :: () -> {ok, proplist()} |  {error, any()}).
+list_instance_profiles_all() ->
+    list_instance_profiles_all(default_config()).
+
+-spec(list_instance_profiles_all/1 :: (string() | aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_instance_profiles_all(#aws_config{} = Config) ->
+    list_instance_profiles_all("/", Config);
+
+list_instance_profiles_all(PathPrefix) ->
+    list_instance_profiles_all(PathPrefix, default_config()).
+
+-spec(list_instance_profiles_all/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
+list_instance_profiles_all(PathPrefix, #aws_config{} = Config) ->
+    ItemPath = "/ListInstanceProfilesResponse/ListInstanceProfilesResult/InstanceProfiles/member",
+    Params = [{"PathPrefix", PathPrefix}],
+    iam_query_all(Config, "ListInstanceProfiles", Params, ItemPath, data_type("InstanceProfile")).
+
+-spec(get_instance_profile/1 :: (string()) -> {ok, proplist()} |  {error, any()}).
 get_instance_profile(ProfileName) ->
     get_instance_profile(ProfileName, default_config()).
 
--spec(get_instance_profile/2 :: (string(), aws_config()) -> proplist()).
+-spec(get_instance_profile/2 :: (string(), aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_instance_profile(ProfileName, #aws_config{} = Config) ->
     ItemPath = "/GetInstanceProfileResponse/GetInstanceProfileResult/InstanceProfile",
     Params = [{"InstanceProfileName", ProfileName}],
@@ -418,11 +642,11 @@ get_instance_profile(ProfileName, #aws_config{} = Config) ->
 %
 % Account APIs
 %
--spec(get_account_authorization_details/0 :: () -> proplist()).
+-spec(get_account_authorization_details/0 :: () -> {ok, proplist()} |  {error, any()}).
 get_account_authorization_details() ->
     get_account_authorization_details(default_config()).
   
--spec(get_account_authorization_details/1 :: (aws_config()) -> proplist()).
+-spec(get_account_authorization_details/1 :: (aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_account_authorization_details(#aws_config{} = Config) ->
     ItemPath = "/GetAccountAuthorizationDetailsResponse/GetAccountAuthorizationDetailsResult",
     DataTypeDef = data_type("AccountAuthorizationDetails"),
@@ -432,11 +656,11 @@ get_account_authorization_details(#aws_config{} = Config) ->
         {error, _} = Error -> Error
     end.
 
--spec(get_account_summary/0 :: () -> proplist()).
+-spec(get_account_summary/0 :: () -> {ok, proplist()} |  {error, any()}).
 get_account_summary() ->
     get_account_summary(default_config()).
 
--spec(get_account_summary/1 :: (aws_config()) -> proplist()).
+-spec(get_account_summary/1 :: (aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_account_summary(#aws_config{} = Config) ->
     case iam_query(Config, "GetAccountSummary", []) of
         {ok, Doc} ->
@@ -446,33 +670,33 @@ get_account_summary(#aws_config{} = Config) ->
             Error
     end.
 
--spec(get_account_password_policy/0 :: () -> proplist()).
+-spec(get_account_password_policy/0 :: () -> {ok, proplist()} |  {error, any()}).
 get_account_password_policy() ->
     get_account_password_policy(default_config()).
 
--spec(get_account_password_policy/1 :: (aws_config()) -> proplist()).
+-spec(get_account_password_policy/1 :: (aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_account_password_policy(#aws_config{} = Config) ->
     ItemPath = "/GetAccountPasswordPolicyResponse/GetAccountPasswordPolicyResult/PasswordPolicy",
     DataTypeDef = data_type("PasswordPolicy"),
     iam_query(Config, "GetAccountPasswordPolicy", [], ItemPath, DataTypeDef).
 
 
--spec(generate_credential_report/0 :: () -> proplist()).
+-spec(generate_credential_report/0 :: () -> {ok, proplist()} |  {error, any()}).
 generate_credential_report() ->
     generate_credential_report(default_config()).
 
--spec(generate_credential_report/1 :: (aws_config()) -> proplist()).
+-spec(generate_credential_report/1 :: (aws_config()) -> {ok, proplist()} |  {error, any()}).
 generate_credential_report(Config) ->
     ItemPath = "/GenerateCredentialReportResponse/GenerateCredentialReportResult",
     DataTypeDef = [{"State", state, "String"},
                    {"Description", description, "String"}],
     iam_query(Config, "GenerateCredentialReport", [], ItemPath, DataTypeDef).
 
--spec(get_credential_report/0 :: () -> proplist()).
+-spec(get_credential_report/0 :: () -> {ok, proplist()} |  {error, any()}).
 get_credential_report() ->
     get_credential_report(default_config()).
 
--spec(get_credential_report/1 :: (aws_config()) -> proplist()).
+-spec(get_credential_report/1 :: (aws_config()) -> {ok, proplist()} |  {error, any()}).
 get_credential_report(Config) ->
     ItemPath = "/GetCredentialReportResponse/GetCredentialReportResult",
     DataTypeDef = [{"GeneratedTime", generated_time, "DateTime"},
@@ -493,9 +717,20 @@ iam_query(Config, Action, Params, ApiVersion) ->
 
 iam_query(Config, Action, Params, ItemPath, DataTypeDef) ->
     case iam_query(Config, Action, Params) of
-        {ok, Doc} ->
-            Items = xmerl_xpath:string(ItemPath, Doc),
-            {ok, [extract_values(DataTypeDef, Item) || Item <- Items]};
+        {ok, Res} ->
+            Items = erlcloud_util:get_items(ItemPath, Res),
+            Result = [extract_values(DataTypeDef, Item) || Item <- Items],
+            erlcloud_util:make_response(Res, Result);
+        {error, _} = Error ->
+            Error
+    end.
+
+iam_query_all(Config, Action, Params, ItemPath, DataTypeDef) ->
+    case erlcloud_util:query_all(fun iam_query/3, Config, Action, Params) of
+        {ok, Res} ->
+            Items = erlcloud_util:get_items(ItemPath, Res),
+            Result = [extract_values(DataTypeDef, Item) || Item <- Items],
+            {ok, Result};
         {error, _} = Error ->
             Error
     end.
@@ -554,6 +789,7 @@ extract_account_summary(Item) ->
                       [{PKey, apply(erlcloud_xml, ValueFun, ["value", E])}|As]
               end
       end, [], Entries).
+
 
 data_type("AccountAuthorizationDetails") ->
     [{"UserDetailList/member", users, data_type("UserDetail")},


### PR DESCRIPTION
IAM requests with pagination were not supported in erlcloud, only first 100 elements were returned.
This PR fixes that issue by introducing Marker field in result of IAM list requests and separate *_all calls which retrieves all available elements in serie of sequential requests.
