### PR TITLE
Add `erlcloud_kinesis:get_records/4` function

### DIFF
--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -311,12 +311,16 @@ get_shard_iterator(StreamName, ShardId, ShardIteratorType, StartingSequenceNumbe
 %% @end
 %%------------------------------------------------------------------------------
 
--spec get_records/1 :: (string()) -> proplist().
+-type get_records_limit() :: 1..10000.
+
+-spec get_records/1 :: (binary()) ->
+    {ok, [proplist()]} | {error, any()}.
 get_records(ShardIterator) ->
     Json = [{<<"ShardIterator">>, ShardIterator}],
     get_normalized_records(default_config(), Json).
 
--spec get_records/2 :: (string(), 1..10000 | aws_config()) -> proplist().
+-spec get_records/2 :: (binary(), get_records_limit() | aws_config()) ->
+    {ok, [proplist()]} | {error, any()}.
 get_records(ShardIterator, Config) when is_record(Config, aws_config) ->
     Json = [{<<"ShardIterator">>, ShardIterator}],
     get_normalized_records(Config, Json);
@@ -324,11 +328,12 @@ get_records(ShardIterator, Limit)
   when is_integer(Limit), Limit > 0, Limit =< 10000 ->
     get_records(ShardIterator, Limit, default_config()).
 
--spec get_records/3 :: (string(), 1..10000, aws_config()) -> proplist().
+-spec get_records/3 :: (binary(), get_records_limit(), aws_config()) ->
+    {ok, [proplist()]} | {error, any()}.
 get_records(ShardIterator, Limit, Config) ->
     get_records(ShardIterator, Limit, [], Config).
 
--spec get_records/4 :: (binary(), 1..10000, proplist(), aws_config()) ->
+-spec get_records/4 :: (binary(), get_records_limit(), proplist(), aws_config()) ->
     {ok, [proplist()] | binary()} | {error, any()}.
 get_records(ShardIterator, Limit, Options, Config)
   when is_record(Config, aws_config),

--- a/src/erlcloud_kinesis.erl
+++ b/src/erlcloud_kinesis.erl
@@ -10,7 +10,7 @@
          list_streams/0, list_streams/1, list_streams/2, list_streams/3,
          describe_stream/1, describe_stream/2, describe_stream/3, describe_stream/4,
          get_shard_iterator/3, get_shard_iterator/4, get_shard_iterator/5,
-         get_records/1, get_records/2, get_records/3,
+         get_records/1, get_records/2, get_records/3, get_records/4,
          put_record/3, put_record/4, put_record/5, put_record/6,
          merge_shards/3, merge_shards/4,
          split_shards/3, split_shards/4
@@ -325,20 +325,31 @@ get_records(ShardIterator, Limit)
     get_records(ShardIterator, Limit, default_config()).
 
 -spec get_records/3 :: (string(), 1..10000, aws_config()) -> proplist().
-get_records(ShardIterator, Limit, Config) when is_record(Config, aws_config),
-                                               is_integer(Limit),
-                                               Limit > 0,
-                                               Limit =< 10000 ->
-    Json = [{<<"ShardIterator">>, ShardIterator}, {<<"Limit">>, Limit}],
-    get_normalized_records(Config, Json).
+get_records(ShardIterator, Limit, Config) ->
+    get_records(ShardIterator, Limit, [], Config).
 
-%% Normalize records from Kinesis
+-spec get_records/4 :: (binary(), 1..10000, proplist(), aws_config()) ->
+    {ok, [proplist()] | binary()} | {error, any()}.
+get_records(ShardIterator, Limit, Options, Config)
+  when is_record(Config, aws_config),
+       is_integer(Limit),
+       Limit > 0, Limit =< 10000 ->
+    Json = [{<<"ShardIterator">>, ShardIterator},
+            {<<"Limit">>, Limit}],
+    ShouldDecode = proplists:get_value(decode, Options, true),
+    get_normalized_records(Config, Json, ShouldDecode).
 
-get_normalized_records(Config, Json) when is_record(Config, aws_config) ->
-  case erlcloud_kinesis_impl:request(Config, "Kinesis_20131202.GetRecords", Json) of
-    {ok, Response} -> {ok, normalize_response(Response)};
-    {error, Msg} -> {error, Msg}
-  end.
+get_normalized_records(Config, Json) ->
+    get_normalized_records(Config, Json, true).
+
+get_normalized_records(Config, Json, ShouldDecode)
+  when is_record(Config, aws_config) ->
+    Request = "Kinesis_20131202.GetRecords",
+    case erlcloud_kinesis_impl:request(Config, Request, Json, ShouldDecode) of
+        {ok, Resp} when is_binary(Resp) -> {ok, Resp};
+        {ok, Resp} -> {ok, normalize_response(Resp)};
+        {error, Reason} -> {error, Reason}
+    end.
 
 
 normalize_record([{K,V} | T]) when K == <<"Data">> -> [ {K, base64:decode(V)} | normalize_record(T) ];

--- a/test/erlcloud_kinesis_tests.erl
+++ b/test/erlcloud_kinesis_tests.erl
@@ -40,6 +40,7 @@ operation_test_() ->
       fun get_shard_iterator_output_tests/1,
       fun get_records_input_tests/1,
       fun get_records_output_tests/1,
+      fun get_records_no_decode_output_tests/1,
       fun put_record_input_tests/1,
       fun put_record_output_tests/1,
       fun merge_shards_input_tests/1,
@@ -444,6 +445,31 @@ get_records_output_tests(_) ->
         ],
 
     output_tests(?_f(erlcloud_kinesis:get_records(<<"AAAAAAAAAAEuncwaAk+GTC2TIdmdg5w6dIuZ4Scu6vaMGPtaPUfopvw9cBm2NM3Rlj9WyI5JFJr2ahuSh3Z187AdW4Lug86E">>)), Tests).
+
+get_records_no_decode_output_tests(_) ->
+    Input = "
+{
+    \"NextShardIterator\": \"AAAAAAAAAAEkuCmrC+QDW1gUywyu7G8GxvRyM6GSMkcHQ9wrvCJBW87mjn9C8YEckkipaoJySwgKXMmn1BwSPjnjiUCsu6pc\",
+    \"Records\": [
+        {
+            \"Data\": \"YXNkYXNk\",
+            \"PartitionKey\": \"key\",
+            \"SequenceNumber\": \"49537292605574028653758531131893428543501381406818304001\"
+        },
+        {
+            \"Data\": \"YXNkYXNkIDIxMzEyMzEyMw==\",
+            \"PartitionKey\": \"key\",
+            \"SequenceNumber\": \"49537292605574028653758541428570459745183078607853977601\"
+        }
+    ]
+}",
+    Tests = [
+        ?_kinesis_test({"GetRecords example response (no decode)", Input,
+                        {ok, list_to_binary(Input)}})
+    ],
+    ShardIterator = <<"AAAAAAAAAAEuncwaAk+GTC2TIdmdg5w6dIuZ4Scu6vaMGPtaPUfopvw9cBm2NM3Rlj9WyI5JFJr2ahuSh3Z187AdW4Lug86E">>,
+    Config = erlcloud_aws:default_config(),
+    output_tests(?_f(erlcloud_kinesis:get_records(ShardIterator, 10000, [{decode, false}], Config)), Tests).
 
 %% PutRecord test based on the API examples:
 %% ttp://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html


### PR DESCRIPTION
This function additionally takes `Options` proplists.
If `{decode, ShouldDecode}` is set to `false` then function will return `binary()` response in case of success without decoding it.
JSON parsing and base64 decoding can take a lot of time, and somebody may want to use other than `jsx` and `base64` libraries to do it.
