### PR TITLE
Do encode colon in a file name.

### DIFF
--- a/src/erlcloud_http.erl
+++ b/src/erlcloud_http.erl
@@ -53,7 +53,7 @@ url_encode_loose([Char|String], Accum)
        Char >= $0, Char =< $9;
        Char =:= $-; Char =:= $_;
        Char =:= $.; Char =:= $~;
-       Char =:= $/; Char =:= $: ->
+       Char =:= $/ ->
     url_encode_loose(String, [Char|Accum]);
 url_encode_loose([Char|String], Accum)
   when Char >=0, Char =< 255 ->


### PR DESCRIPTION
AWS request is signed improperly if a file name contains colon.

```
{aws_error,{http_error,403,"Forbidden",<<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>ASIAJUAU5J2E425ET3LA</AWSAccessKeyId><StringToSign>AWS4-HMAC-SHA256\n20160120T113611Z\n20160120/us-east-1/s3/aws4_request\n265ecea6473565360bb3ed9006ee3bf576f418e743bcc1200518fdb1e6273e56</StringToSign><SignatureProvided>916f6c4294394fe30948e75bc3f724e1e5c5a4ec1d4cb9920943b4001fb69faf</SignatureProvided><StringToSignBytes>41 57 53 34 2d 48 4d 41 43 2d 53 48 41 32 35 36 0a 32 30 31 36 30 31 32 30 54 31 31 33 36 31 31 5a 0a 32 30 31 36 30 31 32 30 2f 75 73 2d 65 61 73 74 2d 31 2f 73 33 2f 61 77 73 34 5f 72 65 71 75 65 73 74 0a 32 36 35 65 63 65 61 36 34 37 33 35 36 35 33 36 30 62 62 33 65 64 39 30 30 36 65 65 33 62 66 35 37 36 66 34 31 38 65 37 34 33 62 63 63 31 32 30 30 35 31 38 66 64 62 31 65 36 32 37 33 65 35 36</StringToSignBytes><CanonicalRequest>GET\n/AWSLogs/314197852177/redshift/us-east-1/2016/01/20/314197852177_redshift_us-east-1_businesspanorama_connectionlog_2016-01-20T10%3A13.gz\n\nhost:itx-agj-logsusea1-dosojtmfnar0.s3.amazonaws.com\nx-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\nx-amz-date:20160120T113611Z\nx-amz-security-token:AQoDYXdzENT//////////wEakAI+SwfBchT5zIVSYmM+nHk0xRfUTqTkYZjheUfkTCdxFiVR2+0yFblIK4ls1xFf1YdrXcKL4NR0ZbxE+ODafOcdDd9EYe6vBipxn5cYULm/VsqJBF+vK9NA9o1TIaLqU2NA5DTvWEq7Um7LZAviyUCZzIQXXbyecSz2DBiAIrI59P4QIHBrahT1tK8kPLdpjQg5PhkiY5wMB/R0fy8yBWAWRh/crgy+9sLJqRRM7+IPSPadh1eOca35mW7QPwKS9pbOUXYGPRMeZwAZQkO+CHT6JmzI7Belm6G0cWnqfmpvrwClLa7HkqlTcQx2ZvsJGRQPx+LJ5Z1wSwQlbm5xqF6A8SMPbexrT9AyGxUy+wu2tCDr1P20BQ==\n\nhost;x-amz-content-sha256;x-amz-date;x-amz-security-token\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855</CanonicalRequest><CanonicalRequestBytes>
```

The colon should be encoded with %3A in order to get proper signature.
