### PR TITLE
Add `erlcloud_kinesis:put_record/7` function

### DIFF
--- a/test/erlcloud_kinesis_tests.erl
+++ b/test/erlcloud_kinesis_tests.erl
@@ -490,6 +490,15 @@ put_record_input_tests(_) ->
   \"PartitionKey\": \"key\"
 }"
             }),
+         ?_kinesis_test(
+             {"PutRecord example request",
+              ?_f(erlcloud_kinesis:put_record(<<"test">>, <<"key">>, <<"abcdef">>, undefined, undefined, [{encode, false}])), "
+{
+  \"Data\": \"abcdef\",
+  \"StreamName\": \"test\",
+  \"PartitionKey\": \"key\"
+}"
+             }),
         ?_kinesis_test(
             {"PutRecord example request",
              ?_f(erlcloud_kinesis:put_record(<<"test">>, <<"key1">>, <<"asdasd 213123123">>)), "


### PR DESCRIPTION
This function additionally takes `Options` proplist.
If `{encode, ShouldEncode}` is set to `false` then function will not encode `Data` to `base64`.
base64 encoding can take a lot of time, and somebody may want to use other than `base64` library to do it.

Also, specs of `put_record/*` are fixed.
