### PR TITLE
Fix policy simulator paginated output

### DIFF
--- a/src/erlcloud_iam.erl
+++ b/src/erlcloud_iam.erl
@@ -711,22 +711,24 @@ simulate_principal_policy(PolicySourceArn, ActionNames) ->
 
 simulate_principal_policy(PolicySourceArn, ActionNames, #aws_config{} = Config)
   when is_list(PolicySourceArn) andalso is_list(ActionNames) ->
-    ItemPath = "/SimulatePrincipalPolicyResponse/SimulatePrincipalPolicyResult",
+    ItemPath = "/SimulatePrincipalPolicyResponse/SimulatePrincipalPolicyResult/"
+               "EvaluationResults/member",
     Params = [{"PolicySourceArn", PolicySourceArn} |
               erlcloud_util:encode_list("ActionNames", ActionNames)],
     iam_query_all(Config, "SimulatePrincipalPolicy", Params,
-                  ItemPath, data_type("EvaluationResults")).
+                  ItemPath, data_type("EvaluationResult")).
 
 simulate_custom_policy(ActionNames, PolicyInputList) ->
     simulate_custom_policy(ActionNames, PolicyInputList, default_config()).
 
 simulate_custom_policy(ActionNames, PolicyInputList, #aws_config{} = Config)
   when is_list(ActionNames), is_list(PolicyInputList) ->
-    ItemPath = "/SimulateCustomPolicyResponse/SimulateCustomPolicyResult",
+    ItemPath = "/SimulateCustomPolicyResponse/SimulateCustomPolicyResult/"
+               "EvaluationResults/member",
     Params = erlcloud_util:encode_list("ActionNames", ActionNames) ++ 
              erlcloud_util:encode_list("PolicyInputList", PolicyInputList),
     iam_query_all(Config, "SimulateCustomPolicy", Params,
-                  ItemPath, data_type("EvaluationResults")).
+                  ItemPath, data_type("EvaluationResult")).
 
 %
 % Utils
@@ -925,9 +927,6 @@ data_type("UserPolicyList") ->
     [{"PolicyDocument", policy_document, "Uri"},
      {"UserName", user_name, "String"},
      {"PolicyName", policy_name, "String"}];
-data_type("EvaluationResults") ->
-    [{"EvaluationResults/member",
-      evaluation_result_list, data_type("EvaluationResult")}];
 data_type("EvaluationResult") ->
     [{"MatchedStatements/member", matched_statements_list,
       data_type("MatchedStatement")},

--- a/test/erlcloud_iam_tests.erl
+++ b/test/erlcloud_iam_tests.erl
@@ -2677,12 +2677,11 @@ simulate_custom_policy_output_test(_) ->
         [?_iam_test(
             {"SimulateCustomPolicy output",
             ?SIMULATE_CUSTOM_POLICY_RESP,
-            {ok, [[{evaluation_result_list,
-                    [[{eval_action_name, "s3:ListBucket"},
-                      {eval_decision, "allowed"},
-                      {eval_resource_name, "arn:aws:s3:::teambucket"},
-                      {matched_statements_list,
-                       [[{source_policy_id, "PolicyInputList.1"}]]}]]}]]}})
+            {ok, [[{eval_action_name, "s3:ListBucket"},
+                   {eval_decision, "allowed"},
+                   {eval_resource_name, "arn:aws:s3:::teambucket"},
+                   {matched_statements_list,
+                    [[{source_policy_id, "PolicyInputList.1"}]]}]]}})
         ],
     output_tests(?_f(erlcloud_iam:simulate_custom_policy(["s3:ListBucket"],
                                                          ["policy_doc1",
@@ -2711,12 +2710,11 @@ simulate_principal_policy_output_test(_) ->
         [?_iam_test(
             {"SimulatePrincipalPolicy output",
             ?SIMULATE_PRINCIPAL_POLICY_RESP,
-            {ok, [[{evaluation_result_list,
-                    [[{eval_action_name, "s3:ListBucket"},
-                      {eval_decision, "allowed"},
-                      {eval_resource_name, "arn:aws:s3:::teambucket"},
-                      {matched_statements_list,
-                       [[{source_policy_id, "PolicyInputList.1"}]]}]]}]]}})
+            {ok, [[{eval_action_name, "s3:ListBucket"},
+                   {eval_decision, "allowed"},
+                   {eval_resource_name, "arn:aws:s3:::teambucket"},
+                   {matched_statements_list,
+                    [[{source_policy_id, "PolicyInputList.1"}]]}]]}})
         ],
     output_tests(?_f(erlcloud_iam:simulate_principal_policy(["arn:aws:iam:::user/Jill"],
                                                             ["s3:ListBucket"])),


### PR DESCRIPTION
Calls to policy simulator will unfold contents of `evaluation_result_list`.
