### PR TITLE
Fixing `get_notification_filter_do` crashes if a bucket notification lacks prefix or suffix

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -560,11 +560,10 @@ get_notification_filter(Path, Config) ->
 get_notification_filter_do([]) -> [];
 get_notification_filter_do(S3Key) ->
     #xmlElement{content = Content} = hd(S3Key),
-    [[{name, "Prefix"}, {value, Prefix}],
-     [{name, "Suffix"}, {value, Suffix}]] =
-    [erlcloud_xml:decode([{name, "Name", text}, {value, "Value", text}], C)
-     || C <- Content],
-    {filter, [{prefix, Prefix}, {suffix, Suffix}]}.
+    GV = fun(Key, PL) -> proplists:get_value(Key, PL) end,
+    Filter0 = [erlcloud_xml:decode([{name, "Name", text}, {value, "Value", text}], C) || C <- Content],
+    Filter = [{list_to_atom(string:to_lower(GV(name, E))), GV(value, E)} || E <- Filter0],
+    {filter, Filter}.
 
 s3_notification_attrs(AttributeName, Attr) ->
     [ {AttributeName, Attr,    text} |

--- a/test/erlcloud_s3_test_data.hrl
+++ b/test/erlcloud_s3_test_data.hrl
@@ -24,6 +24,38 @@
     <Value>images/</Value></FilterRule><FilterRule><Name>Suffix</Name><Value>ico</Value>
     </FilterRule></S3Key></Filter></CloudFunctionConfiguration></NotificationConfiguration>">>).
 
+-define(S3_BUCKET_EVENT_XML_CONFIG_NO_SUFFIX,
+    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <TopicConfiguration><Id>Coolname</Id>
+    <Topic>arn:aws:sns:us-east-1:000000000000:someuser_test</Topic>
+    <Event>s3:ObjectRemoved:Delete</Event>
+    <Event>s3:ObjectCreated:CompleteMultipartUpload</Event>
+    <Event>s3:ObjectCreated:Post</Event>
+    <Filter><S3Key><FilterRule><Name>Prefix</Name><Value>images/</Value></FilterRule></S3Key></Filter>
+    </TopicConfiguration><QueueConfiguration><Id>secondSQSNotification</Id><Queue>arn:aws:sqs:us-east-1:000000000000:someuser-second-sqs-queue</Queue>
+    <Event>s3:ObjectCreated:Post</Event>
+    <Filter><S3Key><FilterRule><Name>Prefix</Name><Value>images/</Value></FilterRule><FilterRule><Name>Suffix</Name><Value>bmp</Value></FilterRule></S3Key></Filter>
+    </QueueConfiguration><CloudFunctionConfiguration><Id>meowpeow</Id><CloudFunction>arn:aws:lambda:us-east-1:000000000000:function:s3collectTestFunction</CloudFunction>
+    <Event>s3:ObjectRemoved:Delete</Event><Filter><S3Key><FilterRule><Name>Prefix</Name>
+    <Value>images/</Value></FilterRule><FilterRule><Name>Suffix</Name><Value>ico</Value>
+    </FilterRule></S3Key></Filter></CloudFunctionConfiguration></NotificationConfiguration>">>).
+
+-define(S3_BUCKET_EVENT_XML_CONFIG_NO_PREFIX,
+    <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <TopicConfiguration><Id>Coolname</Id>
+    <Topic>arn:aws:sns:us-east-1:000000000000:someuser_test</Topic>
+    <Event>s3:ObjectRemoved:Delete</Event>
+    <Event>s3:ObjectCreated:CompleteMultipartUpload</Event>
+    <Event>s3:ObjectCreated:Post</Event>
+    <Filter><S3Key><FilterRule><Name>Suffix</Name><Value>jpg</Value></FilterRule></S3Key></Filter>
+    </TopicConfiguration><QueueConfiguration><Id>secondSQSNotification</Id><Queue>arn:aws:sqs:us-east-1:000000000000:someuser-second-sqs-queue</Queue>
+    <Event>s3:ObjectCreated:Post</Event>
+    <Filter><S3Key><FilterRule><Name>Prefix</Name><Value>images/</Value></FilterRule><FilterRule><Name>Suffix</Name><Value>bmp</Value></FilterRule></S3Key></Filter>
+    </QueueConfiguration><CloudFunctionConfiguration><Id>meowpeow</Id><CloudFunction>arn:aws:lambda:us-east-1:000000000000:function:s3collectTestFunction</CloudFunction>
+    <Event>s3:ObjectRemoved:Delete</Event><Filter><S3Key><FilterRule><Name>Prefix</Name>
+    <Value>images/</Value></FilterRule><FilterRule><Name>Suffix</Name><Value>ico</Value>
+    </FilterRule></S3Key></Filter></CloudFunctionConfiguration></NotificationConfiguration>">>).
+
 -define(S3_BUCKET_EVENTS_SIMPLE_XML_FORM,
     {'NotificationConfiguration',[
         {'TopicConfiguration',[
@@ -55,6 +87,48 @@
     [
         [{topic_configuration, [
             {filter, [{prefix,"images/"}, {suffix,"jpg"}]},
+            {topic,"arn:aws:sns:us-east-1:000000000000:someuser_test"},
+            {id,"Coolname"},
+            {event,["s3:ObjectRemoved:Delete",
+                "s3:ObjectCreated:CompleteMultipartUpload",
+                "s3:ObjectCreated:Post"]}
+        ]}],
+        [{queue_configuration, [
+            {filter, [{prefix,"images/"}, {suffix,"bmp"}]},
+            {queue,"arn:aws:sqs:us-east-1:000000000000:someuser-second-sqs-queue"},
+            {id,"secondSQSNotification"},
+            {event,["s3:ObjectCreated:Post"]}]}],
+        [{cloud_function_configuration, [
+            {filter, [{prefix,"images/"}, {suffix,"ico"}]},
+            {cloud_function,"arn:aws:lambda:us-east-1:000000000000:function:s3collectTestFunction"},
+            {id,"meowpeow"},
+            {event,["s3:ObjectRemoved:Delete"]}]}]]).
+
+-define(S3_BUCKET_EVENTS_LIST_NO_SUFFIX,
+    [
+        [{topic_configuration, [
+            {filter, [{prefix,"images/"}]},
+            {topic,"arn:aws:sns:us-east-1:000000000000:someuser_test"},
+            {id,"Coolname"},
+            {event,["s3:ObjectRemoved:Delete",
+                "s3:ObjectCreated:CompleteMultipartUpload",
+                "s3:ObjectCreated:Post"]}
+        ]}],
+        [{queue_configuration, [
+            {filter, [{prefix,"images/"}, {suffix,"bmp"}]},
+            {queue,"arn:aws:sqs:us-east-1:000000000000:someuser-second-sqs-queue"},
+            {id,"secondSQSNotification"},
+            {event,["s3:ObjectCreated:Post"]}]}],
+        [{cloud_function_configuration, [
+            {filter, [{prefix,"images/"}, {suffix,"ico"}]},
+            {cloud_function,"arn:aws:lambda:us-east-1:000000000000:function:s3collectTestFunction"},
+            {id,"meowpeow"},
+            {event,["s3:ObjectRemoved:Delete"]}]}]]).
+
+-define(S3_BUCKET_EVENTS_LIST_NO_PREFIX,
+    [
+        [{topic_configuration, [
+            {filter, [{suffix,"jpg"}]},
             {topic,"arn:aws:sns:us-east-1:000000000000:someuser_test"},
             {id,"Coolname"},
             {event,["s3:ObjectRemoved:Delete",

--- a/test/erlcloud_s3_tests.erl
+++ b/test/erlcloud_s3_tests.erl
@@ -14,18 +14,21 @@
 
 operation_test_() ->
     {foreach,
-     fun start/0,
-     fun stop/1,
-     [fun get_bucket_policy_tests/1,
-         fun get_bucket_notification_test/1,
-      fun put_object_tests/1,
-      fun error_handling_tests/1,
-      fun dns_compliant_name_tests/1,
-      fun get_bucket_lifecycle_tests/1,
-      fun put_bucket_lifecycle_tests/1,
-      fun delete_bucket_lifecycle_tests/1,
-      fun encode_bucket_lifecycle_tests/1
-     ]}.
+        fun start/0,
+        fun stop/1,
+        [
+            fun get_bucket_policy_tests/1,
+            fun get_bucket_notification_test/1,
+            fun get_bucket_notification_no_prefix_test/1,
+            fun get_bucket_notification_no_suffix_test/1,
+            fun put_object_tests/1,
+            fun error_handling_tests/1,
+            fun dns_compliant_name_tests/1,
+            fun get_bucket_lifecycle_tests/1,
+            fun put_bucket_lifecycle_tests/1,
+            fun delete_bucket_lifecycle_tests/1,
+            fun encode_bucket_lifecycle_tests/1
+        ]}.
 
 start() ->
     meck:new(erlcloud_httpc),
@@ -142,6 +145,20 @@ get_bucket_notification_test(_) ->
     meck:expect(erlcloud_httpc, request,
         fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
     ?_assertEqual(?S3_BUCKET_EVENTS_LIST,
+        erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
+
+get_bucket_notification_no_prefix_test(_) ->
+    Response = {ok, {{200, "OK"}, [], ?S3_BUCKET_EVENT_XML_CONFIG_NO_PREFIX}},
+    meck:expect(erlcloud_httpc, request,
+        fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
+    ?_assertEqual(?S3_BUCKET_EVENTS_LIST_NO_PREFIX,
+        erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
+
+get_bucket_notification_no_suffix_test(_) ->
+    Response = {ok, {{200, "OK"}, [], ?S3_BUCKET_EVENT_XML_CONFIG_NO_SUFFIX}},
+    meck:expect(erlcloud_httpc, request,
+        fun("https://s3.amazonaws.com/?notification", _, _, _, _, _) -> Response end),
+    ?_assertEqual(?S3_BUCKET_EVENTS_LIST_NO_SUFFIX,
                   erlcloud_s3:get_bucket_attribute("BucketName", notification, config())).
 
 get_bucket_policy_tests(_) ->


### PR DESCRIPTION
## Problem

`erlcloud_s3:get_notification_filter_do` will only work if a bucket notification filter has both prefix and suffix defined.
## Solution

Make both prefix and suffix optional in the filter.
## Reviewers

@kkuzmin @motobob 
