### PR TITLE
fix how timeout macro is used

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -87,8 +87,6 @@
          }).
 -type(aws_config() :: #aws_config{}).
 
--define(DEFAULT_TIMEOUT, 10000).
-
 -record(aws_request,
         {
           %% Provided by requesting service

--- a/src/erlcloud_ddb_impl.erl
+++ b/src/erlcloud_ddb_impl.erl
@@ -114,12 +114,8 @@ timeout(1, #aws_config{timeout = undefined}) ->
     %% Shorter timeout on first request. This is to avoid long (5s) failover when first DDB
     %% endpoint doesn't respond
     1000;
-timeout(_, #aws_config{timeout = undefined}) ->
-    %% Longer timeout on subsequent requsets - results in less timeouts when system is
-    %% under heavy load
-    ?DEFAULT_TIMEOUT;
-timeout(_, #aws_config{timeout = Timeout}) ->
-    Timeout.
+timeout(_, #aws_config{} = Cfg) ->
+    erlcloud_aws:get_timeout(Cfg).
 
 -type attempt() :: {attempt, pos_integer()} | {error, term()}.
 

--- a/src/erlcloud_kinesis_impl.erl
+++ b/src/erlcloud_kinesis_impl.erl
@@ -111,7 +111,7 @@ request_and_retry(Config, Headers, Body, ShouldDecode, {attempt, Attempt}) ->
     case erlcloud_httpc:request(
            url(Config), post,
            [{<<"content-type">>, <<"application/x-amz-json-1.1">>} | Headers],
-           Body, timeout(Config), Config) of
+           Body, erlcloud_aws:get_timeout(Config), Config) of
 
         {ok, {{200, _}, _, RespBody}} ->
             Result = case ShouldDecode of
@@ -175,8 +175,3 @@ port_spec(#aws_config{kinesis_port=Port}) ->
 
 decode(<<>>) -> [];
 decode(JSON) -> jsx:decode(JSON).
-
-timeout(#aws_config{timeout = undefined}) ->
-    ?DEFAULT_TIMEOUT;
-timeout(#aws_config{timeout = Timeout}) ->
-    Timeout.

--- a/src/erlcloud_mturk.erl
+++ b/src/erlcloud_mturk.erl
@@ -1613,7 +1613,7 @@ mturk_request(Config, Operation, Params) ->
                  post,
                  [{<<"content-type">>, <<"application/x-www-form-urlencoded">>}],
                  list_to_binary(erlcloud_http:make_query_string(QParams)),
-                 timeout(Config), Config),
+                 erlcloud_aws:get_timeout(Config), Config),
 
     case Response of
         {ok, {{200, _StatusLine}, _Headers, Body}} ->
@@ -1623,8 +1623,3 @@ mturk_request(Config, Operation, Params) ->
         {error, Error} ->
             erlang:error({aws_error, {socket_error, Error}})
     end.
-
-timeout(#aws_config{timeout = undefined}) ->
-    ?DEFAULT_TIMEOUT;
-timeout(#aws_config{timeout = Timeout}) ->
-    Timeout.

--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -66,7 +66,9 @@ request_and_retry(Config, ResultFun, {retry, Request}, MaxAttempts) ->
       } = Request,
     Request2 = Request#aws_request{attempt = Attempt + 1},
     RetryFun = Config#aws_config.retry,
-    case erlcloud_httpc:request(URI, Method, Headers, Body, timeout(Config), Config) of
+    Rsp = erlcloud_httpc:request(URI, Method, Headers, Body,
+        erlcloud_aws:get_timeout(Config), Config),
+    case Rsp of
         {ok, {{Status, StatusLine}, ResponseHeaders, ResponseBody}} ->
             Request3 = Request2#aws_request{
                  response_type = if Status >= 200, Status < 300 -> ok; true -> error end,
@@ -97,8 +99,3 @@ request_and_retry(Config, ResultFun, {retry, Request}, MaxAttempts) ->
                 RetryFun(Request4),
                 MaxAttempts - 1)
     end.
-
-timeout(#aws_config{timeout = undefined}) ->
-    ?DEFAULT_TIMEOUT;
-timeout(#aws_config{timeout = Timeout}) ->
-    Timeout.

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -282,10 +282,7 @@ receive_message(QueueName, AttributeNames, MaxNumberOfMessages,
        VisibilityTimeout =:= none,
        (WaitTimeSeconds >= 0 andalso WaitTimeSeconds =< 20) orelse
        WaitTimeSeconds =:= none ->
-    InitialTimeout = case Config#aws_config.timeout of
-        undefined -> ?DEFAULT_TIMEOUT;
-        _ -> Config#aws_config.timeout
-    end,
+    InitialTimeout = erlcloud_aws:get_timeout(Config),
     TotalTimeout = if
        (WaitTimeSeconds =/= none andalso WaitTimeSeconds >= 0 andalso InitialTimeout =/= infinity) ->
            InitialTimeout + (WaitTimeSeconds * 1000) ;


### PR DESCRIPTION
Problem:
#99

Solution:
remove define.
update how the library used timeout.

@kstarikov @msayler  
