### PR TITLE
Escape special chars in queue name.

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -420,7 +420,7 @@ sqs_request(Config, QueueName, Action, Params) ->
             erlang:error({aws_error, Reason})
     end.
 
-queue_path([$/|_] = QueueName) -> QueueName;
+queue_path([$/|QueueName]) -> [$/ |erlcloud_http:url_encode(QueueName)];
 queue_path([$h,$t,$t,$p|_] = URL) ->
     re:replace(URL, "^https?://[^/]*", "", [{return, list}]);
-queue_path(QueueName) -> [$/|QueueName].
+queue_path(QueueName) -> [$/ | erlcloud_http:url_encode(QueueName)].


### PR DESCRIPTION
### Problem Description

If a queue name contains `:` then `erlcloud_sqs:receive_message()` returns 

```
"Error code: 'SignatureDoesNotMatch'. The request signature we calculated does not match the signature you provided. Please check your AWS Secret Access Key."
```
### Solution Description

Encode special chars in a queue name in order to calculate AWS signature correctly.
### Reviewers

@motobob @lilrooness 
