### PR TITLE
Add new `auto_config/0` to generate credentials

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -272,8 +272,9 @@ default_config() ->
 
 default_config_env() ->
     case {os:getenv("AWS_ACCESS_KEY_ID"), os:getenv("AWS_SECRET_ACCESS_KEY"),
-          os:getenv("AWS_SECURITY_TOKEN", undefined )} of
-        {KeyId, Secret, Token} when is_list(KeyId), is_list(Secret) ->
+          os:getenv("AWS_SECURITY_TOKEN")} of
+        {KeyId, Secret, T} when is_list(KeyId), is_list(Secret) ->
+            Token = if is_list(T) -> T; true -> undefined end,
             #aws_config{access_key_id = KeyId, secret_access_key = Secret,
                         security_token = Token};
         _ -> default_config_profile()

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -26,6 +26,7 @@
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 
 -define(ERLCLOUD_RETRY_TIMEOUT, 10000).
+-define(GREGORIAN_EPOCH_OFFSET, 62167219200).
 
 -record(metadata_credentials,
         {access_key_id :: string(),
@@ -286,7 +287,6 @@ default_config_env() ->
         {error, _} -> #aws_config{}
     end.
 
-
 %%%---------------------------------------------------------------------------
 -spec auto_config() -> {ok, aws_config()} | undefined.
 %%%---------------------------------------------------------------------------
@@ -302,7 +302,7 @@ default_config_env() ->
 %%     environment variables <code>AWS_ACCESS_KEY_ID</code>,
 %%     <code>AWS_SECRET_ACCESS_KEY</code> and
 %%     <code>AWS_SECURITY_TOKEN</code> respectively.  Both the Id and Key
-%%     values must e non-empty for this form of credentials to be considered
+%%     values must be non-empty for this form of credentials to be considered
 %%     valid.</p>
 %%   </li>
 %%
@@ -317,7 +317,7 @@ default_config_env() ->
 %%   </li>
 %% </ol>
 %%
-%% If none if these credential sources are available, this function will
+%% If none of these credential sources are available, this function will
 %% return <code>undefined</code>.
 %%
 auto_config() ->
@@ -359,7 +359,7 @@ config_metadata() ->
                 secret_access_key = Secret,
                 security_token = Token,
                 expiration_gregorian_seconds = GregorianSecs}} ->
-            EpochTimeout = GregorianSecs - 62167219200,
+            EpochTimeout = GregorianSecs - ?GREGORIAN_EPOCH_OFFSET,
             {ok, Config#aws_config {
                    access_key_id = Id, secret_access_key = Secret,
                    security_token = Token, expiration = EpochTimeout }};

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -450,6 +450,7 @@ get_metadata_credentials(Config) ->
             get_credentials_from_metadata(Config)
     end.
 
+timestamp_to_gregorian_seconds(undefined) -> undefined;
 timestamp_to_gregorian_seconds(Timestamp) ->
     {ok, [Yr, Mo, Da, H, M, S], []} = io_lib:fread("~d-~d-~dT~d:~d:~dZ", binary_to_list(Timestamp)),
     calendar:datetime_to_gregorian_seconds({{Yr, Mo, Da}, {H, M, S}}).
@@ -477,16 +478,34 @@ get_credentials_from_metadata(Config) ->
                     {error, Reason};
                 {ok, Json} ->
                     Creds = jsx:decode(Json),
-                    Record = #metadata_credentials
-                        {access_key_id = binary_to_list(proplists:get_value(<<"AccessKeyId">>, Creds)),
-                         secret_access_key = binary_to_list(proplists:get_value(<<"SecretAccessKey">>, Creds)),
-                         security_token = binary_to_list(proplists:get_value(<<"Token">>, Creds)),
-                         expiration_gregorian_seconds = timestamp_to_gregorian_seconds(
-                                                          proplists:get_value(<<"Expiration">>, Creds))},
-                    application:set_env(erlcloud, metadata_credentials, Record),
-                    {ok, Record}
+                    get_credentials_from_metadata_xform( Creds )
             end
     end.
+
+get_credentials_from_metadata_xform( Creds ) ->
+    case {prop_to_list_defined(<<"AccessKeyId">>, Creds),
+          prop_to_list_defined(<<"SecretAccessKey">>, Creds),
+          prop_to_list_defined(<<"Token">>, Creds),
+          timestamp_to_gregorian_seconds(
+            proplists:get_value(<<"Expiration">>, Creds))} of
+        {Id, Key, Token, GregorianExpire} when is_list(Id), is_list(Key),
+                                               is_list(Token),
+                                               is_integer(GregorianExpire) ->
+            Record = #metadata_credentials{
+                        access_key_id = Id, secret_access_key = Key,
+                        security_token = Token,
+                        expiration_gregorian_seconds = GregorianExpire },
+            application:set_env(erlcloud, metadata_credentials, Record),
+            {ok, Record};
+        _ -> {error, metadata_not_available}
+    end.
+
+prop_to_list_defined( Name, Props ) ->
+    case proplists:get_value( Name, Props ) of
+        undefined -> undefined;
+        Value when is_binary(Value) -> binary_to_list(Value)
+    end.
+
 
 port_to_str(Port) when is_integer(Port) ->
     integer_to_list(Port);


### PR DESCRIPTION
This adds a new `auto_config/0` function that will generate a valid `#aws_config{}` record depending on the environment, and in most cases will be all that is needed. In addition, the following improvements are also included:
- Metadata credential generation is made more resilient
- Environment credentials will also include `AWS_SECURITY_TOKEN` if available
