### PR TITLE
back off timeout upon retrying

### DIFF
--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -94,7 +94,7 @@ request_and_retry(Config, ResultFun, {retry, Request}, MaxAttempts) ->
                          error_type = httpc,
                          httpc_error_reason = Reason},
             request_and_retry(
-                Config, 
+                Config#aws_config{timeout = 2 * erlcloud_aws:get_timeout(Config)},
                 ResultFun, 
                 RetryFun(Request4),
                 MaxAttempts - 1)


### PR DESCRIPTION
Problem:
Some API allow making huge requests which eventually fail with httpc client timeout.
We have a default retrying strategy with backing off exponentially the delay between retries.
However that keeps the timeout the same in case of http side errors.

Proposed solution:
increase timeout upon `lhttpc` errors. 

Caveat: it's true, there could be other various httpc client errors so may be separating out `{error, timeout} is a better way.

Please do not merge the PR. This is for discussion on whether the direction is valid at all. 
