### PR TITLE
Minor fix in erlcloud_ec2:describe_network_interfaces

### DIFF
--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -1592,7 +1592,7 @@ describe_regions(RegionNames, Config)
 %
 -spec(describe_network_interfaces/0 :: () -> [proplist()]).
 describe_network_interfaces() ->
-    describe_network_interfaces(none).
+    describe_network_interfaces([]).
 
 -spec(describe_network_interfaces/1 :: (list() | aws_config()) -> [proplist()]).
 describe_network_interfaces(Config)


### PR DESCRIPTION
Problem:
Calling erlcloud_ec2:describe_network_interfaces/0 was consistently returning an error since the wrong default value was assigned to NetworkInterfacesIds parameter.

Solution:
I replaced the wrong default value with the right one. Now the call erlcloud_ec2:describe_network_interfaces/0 returns what it should.
