### PR TITLE
Fix external id maximum length.

### DIFF
--- a/src/erlcloud_sts.erl
+++ b/src/erlcloud_sts.erl
@@ -14,6 +14,7 @@
 
 -define(API_VERSION, "2011-06-15").
 -define(UTC_TO_GREGORIAN, 62167219200).
+-define(EXTERNAL_ID_MAX_LEN, 1224).
 
 
 assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds) ->
@@ -36,7 +37,7 @@ assume_role(AwsConfig, RoleArn, RoleSessionName, DurationSeconds, ExternalId)
     ExternalIdPart =
         case ExternalId of
             undefined -> [];
-            _ when length(ExternalId) >= 2, length(ExternalId) =< 96 -> [{"ExternalId", ExternalId}]
+            _ when length(ExternalId) >= 2, length(ExternalId) =< ?EXTERNAL_ID_MAX_LEN -> [{"ExternalId", ExternalId}]
         end,
 
     Xml = sts_query(AwsConfig, "AssumeRole", Params ++ ExternalIdPart),


### PR DESCRIPTION
AWS allows external ID up to 1224 chars long https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html